### PR TITLE
Enable unittest in pytorch nightly version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,10 +28,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Install PyTorch Nightly
       run: |
         pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    - name: Test with pytest
+      run: |
+        pytest test
     - name: Build TorchVision Cpp Nightly
       run: |
         export TORCH_PATH=$(dirname $(python -c "import torch; print(torch.__file__)"))


### PR DESCRIPTION
There are something wrong of `onnx` and `onnxruntime` unittest in nightly version, refer to https://github.com/pytorch/vision/issues/3007