### PR TITLE
Fix ops missing from upstream

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,6 @@ jobs:
     - name: Install PyTorch Nightly
       run: |
         pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-        pip install --user -i https://test.pypi.org/simple/ ort-nightly==1.5.2.dev202012031
     - name: Test with pytest
       run: |
         pytest test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -33,7 +33,6 @@ jobs:
     - name: Install PyTorch 1.7.1
       run: |
         pip install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
-        pip install onnxruntime
     - name: Test with pytest
       run: |
         pytest test

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest]
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ scipy>=1.4.1
 tensorboard>=2.2
 tqdm>=4.41.0
 onnx>=1.8.0
-# onnxruntime>=1.5.2  # pytorch nightly needs to rely on matching with ort-nightly
+onnxruntime>=1.6.0
 # pycocotools need python3.7 as minimal
 # pip install -U pycocotools>=2.0.2  # corresponds to https://github.com/ppwwyyxx/cocoapi

--- a/test/tracing/test_tracing.cpp
+++ b/test/tracing/test_tracing.cpp
@@ -2,7 +2,7 @@
 #include <torch/torch.h>
 
 #include <torchvision/vision.h>
-#include <torchvision/nms.h>
+#include <torchvision/ops/nms.h>
 
 
 int main() {


### PR DESCRIPTION
This is updated with libtorch restructuring from https://github.com/pytorch/vision/pull/3146 and onnxruntime unstream updating from https://github.com/pytorch/vision/pull/3160 .