### PR TITLE
Add mAP evaluation for COCO and VOC datasets

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -4,7 +4,7 @@ import torch
 from yolort.models.backbone_utils import darknet_pan_backbone
 from yolort.models.yolotr import darknet_pan_tr_backbone
 from yolort.models.anchor_utils import AnchorGenerator
-from yolort.models.box_head import YoloHead, PostProcess, SetCriterion
+from yolort.models.box_head import YOLOHead, PostProcess, SetCriterion
 
 from .common_utils import TestCase
 
@@ -152,7 +152,7 @@ class ModelTester(TestCase):
         num_anchors = self._get_num_anchors()
         num_classes = self._get_num_classes()
         strides = self._get_strides()
-        box_head = YoloHead(in_channels, num_anchors, strides, num_classes)
+        box_head = YOLOHead(in_channels, num_anchors, strides, num_classes)
         return box_head
 
     def test_yolo_head(self):

--- a/yolort/datasets/coco.py
+++ b/yolort/datasets/coco.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import torch
 import torch.utils.data
 import torchvision
-from pycocotools import mask as coco_mask
+
+try:
+    from pycocotools import mask as coco_mask
+except ImportError:
+    coco_mask = None
 
 
 class ConvertCocoPolysToMask(object):

--- a/yolort/models/box_head.py
+++ b/yolort/models/box_head.py
@@ -283,7 +283,7 @@ class SetCriterion(nn.Module):
 
                 # Objectness head
                 # iou ratio
-                ciou_vals = torch.tensor(ciou.detach().clamp(0), dtype=obj_logits.dtype)
+                ciou_vals = ciou.clone().detach().clamp(0).requires_grad_(True)
                 obj_logits[b, a, gj, gi] = (1.0 - self.iou_ratio) + (self.iou_ratio * ciou_vals)
 
                 # Classification head

--- a/yolort/models/box_head.py
+++ b/yolort/models/box_head.py
@@ -10,7 +10,7 @@ from . import _utils as det_utils
 from typing import Tuple, List, Dict
 
 
-class YoloHead(nn.Module):
+class YOLOHead(nn.Module):
     def __init__(self, in_channels: List[int], num_anchors: int, strides: List[int], num_classes: int):
         super().__init__()
         self.num_anchors = num_anchors  # anchors
@@ -25,7 +25,7 @@ class YoloHead(nn.Module):
 
     def _initialize_biases(self, cf=None):
         """
-        Initialize biases into YoloHead, cf is class frequency
+        Initialize biases into YOLOHead, cf is class frequency
         Check section 3.3 in <https://arxiv.org/abs/1708.02002>
         """
         for mi, s in zip(self.head, self.strides):

--- a/yolort/models/yolo.py
+++ b/yolort/models/yolo.py
@@ -9,7 +9,7 @@ from torchvision.models.utils import load_state_dict_from_url
 from .backbone_utils import darknet_pan_backbone
 from .yolotr import darknet_pan_tr_backbone
 from .anchor_utils import AnchorGenerator
-from .box_head import YoloHead, SetCriterion, PostProcess
+from .box_head import YOLOHead, SetCriterion, PostProcess
 
 from typing import Tuple, Any, List, Dict, Optional
 
@@ -54,7 +54,7 @@ class YOLO(nn.Module):
         self.compute_loss = loss_calculator
 
         if head is None:
-            head = YoloHead(
+            head = YOLOHead(
                 backbone.out_channels,
                 anchor_generator.num_anchors,
                 anchor_generator.strides,

--- a/yolort/models/yolo_module.py
+++ b/yolort/models/yolo_module.py
@@ -99,8 +99,9 @@ class YOLOModule(LightningModule):
         The training step.
         """
         loss_dict = self.run_step(batch)
-        loss = sum(loss for loss in loss_dict.values())
-        return {"loss": loss, "log": loss_dict}
+        loss = sum(loss_dict.values())
+        self.log_dict(loss_dict, on_step=True, on_epoch=True, prog_bar=True)
+        return loss
 
     def validation_step(self, batch, batch_idx):
         _, targets = batch


### PR DESCRIPTION
Closes part of #59

- [ ] Fix the dataset pipelines
- [ ] Support mAP metrics computing on COCO datasets
- [ ] Support mAO metrics computing on VOC datasets 