### PR TITLE
Made targets argument in YOLOTransform.forward() truly optional.

### DIFF
--- a/yolort/models/transform.py
+++ b/yolort/models/transform.py
@@ -55,7 +55,7 @@ class YOLOTransform(nn.Module):
     def forward(
         self,
         images: List[Tensor],
-        targets: Optional[List[Dict[str, Tensor]]],
+        targets: Optional[List[Dict[str, Tensor]]] = None,
     ) -> Tuple[NestedTensor, Optional[Tensor]]:
         device = images[0].device
         images = [img for img in images]


### PR DESCRIPTION
`targets` was missing a default value of `None` making using YOLOTransform on its own require explicitly passing `None` during inference.