### PR TITLE
AnchorGenerator forces torch.arange in fp32 to allow export to onnx

### DIFF
--- a/yolort/models/anchor_utils.py
+++ b/yolort/models/anchor_utils.py
@@ -68,8 +68,8 @@ class AnchorGenerator(nn.Module):
             grid_height, grid_width = size
 
             # For output anchor, compute [x_center, y_center, x_center, y_center]
-            shifts_x = torch.arange(0, grid_width, dtype=dtype, device=device)
-            shifts_y = torch.arange(0, grid_height, dtype=dtype, device=device)
+            shifts_x = torch.arange(0, grid_width, dtype=torch.float32, device=device).type(dtype)
+            shifts_y = torch.arange(0, grid_height, dtype=torch.float32, device=device).type(dtype)
             shift_y, shift_x = torch.meshgrid(shifts_y, shifts_x)
 
             shifts = torch.stack((shift_x, shift_y), dim=2)

--- a/yolort/models/anchor_utils.py
+++ b/yolort/models/anchor_utils.py
@@ -68,8 +68,9 @@ class AnchorGenerator(nn.Module):
             grid_height, grid_width = size
 
             # For output anchor, compute [x_center, y_center, x_center, y_center]
-            shifts_x = torch.arange(0, grid_width, dtype=torch.float32, device=device).type(dtype)
-            shifts_y = torch.arange(0, grid_height, dtype=torch.float32, device=device).type(dtype)
+            shifts_x = torch.arange(0, grid_width, dtype=torch.float32, device=device).to(dtype=dtype)
+            shifts_y = torch.arange(0, grid_height, dtype=torch.float32, device=device).to(dtype=dtype)
+
             shift_y, shift_x = torch.meshgrid(shifts_y, shifts_x)
 
             shifts = torch.stack((shift_x, shift_y), dim=2)


### PR DESCRIPTION
torch.arange cannot export to onnx with fp16 precision so it is necessary to force the operation into fp32 and then cast the result to the desired dtype.