### PR TITLE
Add coco metrics evaluation CLI

### DIFF
--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -96,15 +96,15 @@ def test_vanilla_coco_evaluator():
     coco = data_helper.get_coco_api_from_dataset(val_dataloader.dataset)
     coco_evaluator = COCOEvaluator(coco)
     # Load model
-    model = yolov5s(pretrained=True, score_thresh=0.001)
+    model = yolov5s(pretrained=True)
     model.eval()
     for images, targets in val_dataloader:
         preds = model(images)
         coco_evaluator.update(preds, targets)
 
     results = coco_evaluator.compute()
-    assert results['AP'] > 38.1
-    assert results['AP50'] > 59.9
+    assert results['AP'] > 37.8
+    assert results['AP50'] > 59.6
 
 
 def test_test_epoch_end():
@@ -118,15 +118,15 @@ def test_test_epoch_end():
     val_dataloader = data_helper.get_dataloader(data_root=data_path, mode='val')
 
     # Load model
-    model = yolov5s(pretrained=True, score_thresh=0.001, annotation_path=annotation_file)
+    model = yolov5s(pretrained=True, annotation_path=annotation_file)
 
     # test step
     trainer = pl.Trainer(max_epochs=1)
     trainer.test(model, test_dataloaders=val_dataloader)
     # test epoch end
     results = model.evaluator.compute()
-    assert results['AP'] > 38.1
-    assert results['AP50'] > 59.9
+    assert results['AP'] > 37.8
+    assert results['AP50'] > 59.6
 
 
 def test_predict_with_vanilla_model():

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -1,57 +1,118 @@
 from pathlib import Path
-
+import argparse
 import torch
+
+from yolort import models
 
 from yolort.data import COCOEvaluator
 from yolort.data.coco import COCODetection
 from yolort.data.transforms import default_val_transforms, collate_fn
-from yolort.data._helper import get_coco_api_from_dataset
-from yolort.models import yolov5s
+from yolort.data import _helper as data_helper
 
-device = torch.device('cuda')
 
-# Setup the coco dataset and dataloader for validation
-# Acquire the images and labels from the coco128 dataset
-data_path = Path('data-bin')
-coco_path = data_path / 'mscoco' / 'coco2017'
-image_root = coco_path / 'val2017'
-annotation_file = coco_path / 'annotations' / 'instances_val2017.json'
+def get_parser():
+    parser = argparse.ArgumentParser('Evaluation CLI for yolort', add_help=True)
 
-# Define the dataloader
-batch_size = 16
-val_dataset = COCODetection(image_root, annotation_file, default_val_transforms())
-# We adopt the sequential sampler in order to repeat the experiment
-sampler = torch.utils.data.SequentialSampler(val_dataset)
+    parser.add_argument('--num_gpus', default=0, type=int, metavar='N',
+                        help='Number of gpu utilizing (default: 0)')
+    # Model architecture
+    parser.add_argument('--arch', default='yolov5s',
+                        help='Model structure to train')
+    parser.add_argument('--num_classes', default=80, type=int,
+                        help='Classes number of the model')
+    parser.add_argument('--score_thresh', default=0.005, type=float,
+                        help='score threshold for mAP evaluation')
+    # Dataset Configuration
+    parser.add_argument('--image_path', default='./data-bin/coco128/images/train2017',
+                        help='Root path of the dataset containing images')
+    parser.add_argument('--annotation_path', default=None,
+                        help='Path of the annotation file')
+    parser.add_argument('--batch_size', default=32, type=int,
+                        help='Images per gpu, the total batch size is $NGPU x batch_size')
+    parser.add_argument('--num_workers', default=8, type=int, metavar='N',
+                        help='Number of data loading workers (default: 8)')
 
-val_dataloader = torch.utils.data.DataLoader(
-    val_dataset,
-    batch_size,
-    sampler=sampler,
-    drop_last=False,
-    collate_fn=collate_fn,
-    num_workers=12,
-)
+    parser.add_argument('--output_dir', default='.',
+                        help='Path where to save')
+    return parser
 
-coco_gt = get_coco_api_from_dataset(val_dataset)
-coco_evaluator = COCOEvaluator(coco_gt)
 
-# Model Definition and Initialization
-model = yolov5s(
-    pretrained=True,
-    min_size=640,
-    max_size=640,
-    score_thresh=0.001,
-)
-model = model.eval()
-model = model.to(device)
+def prepare_data(image_root, annotation_file, batch_size, num_workers):
+    """
+    Setup the coco dataset and dataloader for validation
+    """
+    # Define the dataloader
+    data_set = COCODetection(image_root, annotation_file, default_val_transforms())
 
-# COCO evaluation
-for images, targets in val_dataloader:
-    images = [image.to(device) for image in images]
-    preds = model(images)
-    coco_evaluator.update(preds, targets)
+    # We adopt the sequential sampler in order to repeat the experiment
+    sampler = torch.utils.data.SequentialSampler(data_set)
 
-results = coco_evaluator.compute()
+    data_loader = torch.utils.data.DataLoader(
+        data_set,
+        batch_size,
+        sampler=sampler,
+        drop_last=False,
+        collate_fn=collate_fn,
+        num_workers=num_workers,
+    )
 
-# Format the results
-coco_evaluator.derive_coco_results()
+    return data_set, data_loader
+
+
+def eval_metric(args):
+    if args.num_gpus == 0:
+        device = torch.device('cpu')
+    elif args.num_gpus == 1:
+        device = torch.device('cuda')
+    else:
+        raise NotImplementedError("Currently not supported multi-GPUs mode")
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    # Prepare the dataset and dataloader for evaluation
+    image_path = Path(args.image_path)
+    annotation_path = Path(args.annotation_path)
+
+    data_set, data_loader = prepare_data(
+        image_path,
+        annotation_path,
+        args.batch_size,
+        args.num_workers,
+    )
+
+    coco_gt = data_helper.get_coco_api_from_dataset(data_set)
+    coco_evaluator = COCOEvaluator(coco_gt)
+
+    # Model Definition and Initialization
+    model = models.__dict__[args.arch](
+        pretrained=True,
+        num_classes=args.num_classes,
+        score_thresh=args.score_thresh,
+    )
+
+    model = model.eval()
+    model = model.to(device)
+
+    # COCO evaluation
+    with torch.no_grad():
+        for images, targets in data_loader:
+            images = [image.to(device) for image in images]
+            preds = model(images)
+            coco_evaluator.update(preds, targets)
+
+    results = coco_evaluator.compute()
+
+    # Format the results
+    coco_evaluator.derive_coco_results()
+    print(f'results: {results}')
+
+
+def cli_main():
+    parser = get_parser()
+    args = parser.parse_args()
+    print(args)
+    eval_metric(args)
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import torch
+
+from yolort.data import COCOEvaluator
+from yolort.data.coco import COCODetection
+from yolort.data.transforms import default_val_transforms, collate_fn
+from yolort.data._helper import get_coco_api_from_dataset
+from yolort.models import yolov5s
+
+device = torch.device('cuda')
+
+# Setup the coco dataset and dataloader for validation
+# Acquire the images and labels from the coco128 dataset
+data_path = Path('data-bin')
+coco_path = data_path / 'mscoco' / 'coco2017'
+image_root = coco_path / 'val2017'
+annotation_file = coco_path / 'annotations' / 'instances_val2017.json'
+
+# Define the dataloader
+batch_size = 16
+val_dataset = COCODetection(image_root, annotation_file, default_val_transforms())
+# We adopt the sequential sampler in order to repeat the experiment
+sampler = torch.utils.data.SequentialSampler(val_dataset)
+
+val_dataloader = torch.utils.data.DataLoader(
+    val_dataset,
+    batch_size,
+    sampler=sampler,
+    drop_last=False,
+    collate_fn=collate_fn,
+    num_workers=12,
+)
+
+coco_gt = get_coco_api_from_dataset(val_dataset)
+coco_evaluator = COCOEvaluator(coco_gt)
+
+# Model Definition and Initialization
+model = yolov5s(
+    pretrained=True,
+    min_size=640,
+    max_size=640,
+    score_thresh=0.001,
+)
+model = model.eval()
+model = model.to(device)
+
+# COCO evaluation
+for images, targets in val_dataloader:
+    images = [image.to(device) for image in images]
+    preds = model(images)
+    coco_evaluator.update(preds, targets)
+
+results = coco_evaluator.compute()
+
+# Format the results
+coco_evaluator.derive_coco_results()

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import pytorch_lightning as pl
 
-from .data import COCODetectionDataModule
-from . import models
+from yolort import models
+from yolort.data import COCODetectionDataModule
 
 
 def get_args_parser():

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -8,7 +8,7 @@ from yolort.data import COCODetectionDataModule
 
 
 def get_args_parser():
-    parser = argparse.ArgumentParser('You only look once detector', add_help=False)
+    parser = argparse.ArgumentParser('You only look once detector', add_help=True)
 
     parser.add_argument('--arch', default='yolov5s',
                         help='model structure to train')

--- a/yolort/models/yolo.py
+++ b/yolort/models/yolo.py
@@ -60,8 +60,8 @@ class YOLO(nn.Module):
         iou_thresh: float = 0.5,
         criterion: Optional[Callable[..., Dict[str, Tensor]]] = None,
         # Post Process parameter
-        score_thresh: float = 0.05,
-        nms_thresh: float = 0.5,
+        score_thresh: float = 0.005,
+        nms_thresh: float = 0.45,
         detections_per_img: int = 300,
         post_process: Optional[nn.Module] = None,
     ):


### PR DESCRIPTION
For `yolov5`, run following script:

```bash
CUDA_VISIBLE_DEVICES=1 python tools/eval_metric.py \
    --num_gpus 1 \
    --image_path ./data-bin/mscoco/coco2017/val2017/ \
    --annotation_path ./data-bin/mscoco/coco2017/annotations/instances_val2017.json
```
The expected results of `yolort.models.yolov5s`:

```
The evaluated mAP 0.5:095 is 32.311, and mAP 0.5 is 51.168.
```

_**Note**: Because we are using different dataloder in `yolort` to make yolov5 `torch.jit.scriptable`, so the mAP is not equal to `ultralytics/yolov5`, checkout #92 for more details._

For `torchvision`, run following script:

```bash
CUDA_VISIBLE_DEVICES=1 python tools/eval_metric.py \
    --num_gpus 1 \
    --num_classes 91 \
    --batch_size 4 \
    --arch fasterrcnn_resnet50_fpn \
    --eval_type torchvision \
    --image_path ./data-bin/mscoco/coco2017/val2017/ \
    --annotation_path ./data-bin/mscoco/coco2017/annotations/instances_val2017.json
```

The expected results of `torchvision.models.detection.fasterrcnn_resnet50_fpn`:

```
The evaluated mAP 0.5:095 is 36.873, and mAP 0.5 is 58.495.
```

<details>

<summary>Click to display the metrics originally calculated by `torchvision`.</summary>
<br>
The evaluation scripts is copy-pasted from <https://github.com/pytorch/vision/tree/master/references/detection>.

```
CUDA_VISIBLE_DEVICES=1 python train.py \
    --dataset coco --data-path ./data-bin/mscoco/coco2017/ \
    --model fasterrcnn_resnet50_fpn \
    --batch-size 16 \
    --pretrained \
    --test-only
```

```
Averaged stats: model_time: 0.0727 (0.0692)  evaluator_time: 0.0046 (0.0084)
Accumulating evaluation results...
DONE (t=5.12s).
IoU metric: bbox
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.369
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.585
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.396
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.212
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.403
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.482
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.307
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.485
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.509
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.317
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.544
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.649
```

</details>