### PR TITLE
Change dtype from torch.float32 to torch.int32 in anchor_utils.py

### DIFF
--- a/yolort/models/anchor_utils.py
+++ b/yolort/models/anchor_utils.py
@@ -68,8 +68,8 @@ class AnchorGenerator(nn.Module):
             grid_height, grid_width = size
 
             # For output anchor, compute [x_center, y_center, x_center, y_center]
-            shifts_x = torch.arange(0, grid_width, dtype=torch.float32, device=device).to(dtype=dtype)
-            shifts_y = torch.arange(0, grid_height, dtype=torch.float32, device=device).to(dtype=dtype)
+            shifts_x = torch.arange(0, grid_width, dtype=torch.int32, device=device).to(dtype=dtype)
+            shifts_y = torch.arange(0, grid_height, dtype=torch.int32, device=device).to(dtype=dtype)
 
             shift_y, shift_x = torch.meshgrid(shifts_y, shifts_x)
 


### PR DESCRIPTION
Following the upstream https://github.com/pytorch/vision/pull/4409 .

cc @dkloving . I remember that you also encountered some issues here when you did the `fp16` conversion before, so if this modification affects your subsequent use, please don't mind letting me know.