### PR TITLE
Fix dynamic shape when exporting ONNX

### DIFF
--- a/notebooks/export-onnx-inference-onnxruntime.ipynb
+++ b/notebooks/export-onnx-inference-onnxruntime.ipynb
@@ -90,7 +90,16 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.6/dist-packages/torch/nn/functional.py:718: UserWarning: Named tensors and all their associated APIs are an experimental feature and subject to change. Please do not use them for anything important until they are released as stable. (Triggered internally at  /pytorch/c10/core/TensorImpl.h:1156.)\n",
+      "  return torch.max_pool2d(input, kernel_size, stride, padding, dilation, ceil_mode)\n"
+     ]
+    }
+   ],
    "source": [
     "with torch.no_grad():\n",
     "    model_out = model(images)"
@@ -105,8 +114,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.74 s, sys: 288 ms, total: 4.03 s\n",
-      "Wall time: 142 ms\n"
+      "CPU times: user 3.44 s, sys: 20 ms, total: 3.46 s\n",
+      "Wall time: 96.9 ms\n"
      ]
     }
    ],
@@ -124,10 +133,10 @@
     {
      "data": {
       "text/plain": [
-       "tensor([[669.2656, 391.3025, 809.8663, 885.2344],\n",
-       "        [ 54.0635, 397.8318, 235.9532, 901.3732],\n",
-       "        [222.8834, 406.8119, 341.5572, 854.7792],\n",
-       "        [ 18.6320, 232.9768, 810.9739, 760.1170]])"
+       "tensor([[669.26556, 391.30249, 809.86627, 885.23444],\n",
+       "        [ 54.06350, 397.83176, 235.95316, 901.37323],\n",
+       "        [222.88336, 406.81192, 341.55716, 854.77924],\n",
+       "        [ 18.63205, 232.97676, 810.97394, 760.11700]])"
       ]
      },
      "execution_count": 7,
@@ -147,7 +156,7 @@
     {
      "data": {
       "text/plain": [
-       "tensor([0.8901, 0.8733, 0.8537, 0.7234])"
+       "tensor([0.89005, 0.87333, 0.85366, 0.72340])"
       ]
      },
      "execution_count": 8,
@@ -223,11 +232,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.6/dist-packages/torch/onnx/utils.py:1112: UserWarning: No names were found for specified dynamic axes of provided input.Automatically generated names will be applied to each dynamic axes of input images_tensors\n",
+      "/usr/local/lib/python3.6/dist-packages/torch/onnx/utils.py:1192: UserWarning: No names were found for specified dynamic axes of provided input.Automatically generated names will be applied to each dynamic axes of input images_tensors\n",
       "  'Automatically generated names will be applied to each dynamic axes of input {}'.format(key))\n",
-      "/usr/local/lib/python3.6/dist-packages/torch/onnx/utils.py:1109: UserWarning: Provided key outputs for dynamic axes is not a valid input/output name\n",
-      "  warnings.warn(\"Provided key {} for dynamic axes is not a valid input/output name\".format(key))\n",
-      "/usr/local/lib/python3.6/dist-packages/torch/onnx/utils.py:1112: UserWarning: No names were found for specified dynamic axes of provided input.Automatically generated names will be applied to each dynamic axes of input outputs\n",
+      "/usr/local/lib/python3.6/dist-packages/torch/onnx/utils.py:1192: UserWarning: No names were found for specified dynamic axes of provided input.Automatically generated names will be applied to each dynamic axes of input boxes\n",
+      "  'Automatically generated names will be applied to each dynamic axes of input {}'.format(key))\n",
+      "/usr/local/lib/python3.6/dist-packages/torch/onnx/utils.py:1192: UserWarning: No names were found for specified dynamic axes of provided input.Automatically generated names will be applied to each dynamic axes of input labels\n",
+      "  'Automatically generated names will be applied to each dynamic axes of input {}'.format(key))\n",
+      "/usr/local/lib/python3.6/dist-packages/torch/onnx/utils.py:1192: UserWarning: No names were found for specified dynamic axes of provided input.Automatically generated names will be applied to each dynamic axes of input scores\n",
       "  'Automatically generated names will be applied to each dynamic axes of input {}'.format(key))\n",
       "/data/wangzq/yolov5-rt-stack/yolort/models/anchor_utils.py:31: TracerWarning: torch.as_tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.\n",
       "  stride = torch.as_tensor([stride], dtype=dtype, device=device)\n",
@@ -235,15 +246,13 @@
       "  anchor_grid = torch.as_tensor(anchor_grid, dtype=dtype, device=device)\n",
       "/data/wangzq/yolov5-rt-stack/yolort/models/anchor_utils.py:79: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.\n",
       "  shifts = shifts - torch.tensor(0.5, dtype=shifts.dtype, device=device)\n",
-      "/data/wangzq/yolov5-rt-stack/yolort/models/box_head.py:169: TracerWarning: Converting a tensor to a Python index might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!\n",
-      "  for idx in range(batch_size):  # image idx, image inference\n",
-      "/data/wangzq/yolov5-rt-stack/yolort/models/transform.py:291: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.\n",
+      "/data/wangzq/yolov5-rt-stack/yolort/models/transform.py:298: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.\n",
       "  for s, s_orig in zip(new_size, original_size)\n",
-      "/data/wangzq/yolov5-rt-stack/yolort/models/transform.py:291: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "/data/wangzq/yolov5-rt-stack/yolort/models/transform.py:298: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
       "  for s, s_orig in zip(new_size, original_size)\n",
-      "/usr/local/lib/python3.6/dist-packages/torch/onnx/symbolic_opset9.py:2378: UserWarning: Exporting aten::index operator of advanced indexing in opset 11 is achieved by combination of multiple ONNX operators, including Reshape, Transpose, Concat, and Gather. If indices include negative values, the exported graph will produce incorrect results.\n",
+      "/usr/local/lib/python3.6/dist-packages/torch/onnx/symbolic_opset9.py:2766: UserWarning: Exporting aten::index operator of advanced indexing in opset 11 is achieved by combination of multiple ONNX operators, including Reshape, Transpose, Concat, and Gather. If indices include negative values, the exported graph will produce incorrect results.\n",
       "  \"If indices include negative values, the exported graph will produce incorrect results.\")\n",
-      "/usr/local/lib/python3.6/dist-packages/torch/onnx/symbolic_opset9.py:588: UserWarning: This model contains a squeeze operation on dimension 1 on an input with unknown shape. Note that if the size of dimension 1 of the input is not 1, the ONNX model will return an error. Opset version 11 supports squeezing on non-singleton dimensions, it is recommended to export this model using opset version 11 or higher.\n",
+      "/usr/local/lib/python3.6/dist-packages/torch/onnx/symbolic_opset9.py:701: UserWarning: This model contains a squeeze operation on dimension 1 on an input with unknown shape. Note that if the size of dimension 1 of the input is not 1, the ONNX model will return an error. Opset version 11 supports squeezing on non-singleton dimensions, it is recommended to export this model using opset version 11 or higher.\n",
       "  \"version 11 or higher.\")\n"
      ]
     }
@@ -255,10 +264,15 @@
     "    (images,),\n",
     "    export_onnx_name,\n",
     "    do_constant_folding=True,\n",
-    "    opset_version=_onnx_opset_version,\n",
-    "    dynamic_axes={\"images_tensors\": [0, 1, 2], \"outputs\": [0, 1, 2]}, \n",
+    "    opset_version=_onnx_opset_version, \n",
     "    input_names=[\"images_tensors\"],\n",
     "    output_names=[\"scores\", \"labels\", \"boxes\"],\n",
+    "    dynamic_axes={\n",
+    "        \"images_tensors\": [0, 1, 2],\n",
+    "        \"boxes\": [0, 1],\n",
+    "        \"labels\": [0],\n",
+    "        \"scores\": [0],\n",
+    "    },\n",
     ")"
    ]
   },
@@ -291,7 +305,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Starting simplifing with onnxsim 0.3.3\n"
+      "Starting simplifing with onnxsim 0.3.6\n"
      ]
     }
    ],
@@ -360,7 +374,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Starting with onnx 1.9.0, onnxruntime 1.7.0...\n"
+      "Starting with onnx 1.9.0, onnxruntime 1.8.1...\n"
      ]
     }
    ],
@@ -431,8 +445,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.86 s, sys: 8 ms, total: 2.86 s\n",
-      "Wall time: 87 ms\n"
+      "CPU times: user 2.38 s, sys: 20 ms, total: 2.4 s\n",
+      "Wall time: 65.1 ms\n"
      ]
     }
    ],


### PR DESCRIPTION
As mentioned in https://github.com/zhiqwang/yolov5-rt-stack/pull/171#issuecomment-925482780, we should use the dynamic output shape when exporting the ONNX models.