### PR TITLE
Revert `SPPF` to `SPP`

### DIFF
--- a/yolort/models/darknetv4.py
+++ b/yolort/models/darknetv4.py
@@ -4,7 +4,7 @@ from typing import Callable, List, Optional, Any
 import torch
 from torch import nn, Tensor
 from yolort.utils import load_state_dict_from_url
-from yolort.v5 import Conv, Focus, BottleneckCSP, C3, SPPF
+from yolort.v5 import Conv, Focus, BottleneckCSP, C3, SPP
 
 from ._utils import _make_divisible
 
@@ -95,7 +95,7 @@ class DarkNetV4(nn.Module):
         # building last CSP blocks
         last_channel = _make_divisible(last_channel * width_multiple, round_nearest)
         layers.append(Conv(input_channel, last_channel, k=3, s=2, version=version))
-        layers.append(SPPF(last_channel, last_channel, k=5, version=version))
+        layers.append(SPP(last_channel, last_channel, k=(5, 9, 13), version=version))
 
         self.features = nn.Sequential(*layers)
         self.avgpool = nn.AdaptiveAvgPool2d(1)

--- a/yolort/models/path_aggregation_network.py
+++ b/yolort/models/path_aggregation_network.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Callable, Optional
 
 import torch
 from torch import nn, Tensor
-from yolort.v5 import Conv, BottleneckCSP, C3, SPPF
+from yolort.v5 import Conv, BottleneckCSP, C3, SPP
 
 
 class IntermediateLevelP6(nn.Module):
@@ -106,7 +106,7 @@ class PathAggregationNetwork(nn.Module):
         depth_gain = max(round(3 * depth_multiple), 1)
 
         if version == "r6.0":
-            init_block = SPPF(in_channels[-1], in_channels[-1], k=5)
+            init_block = SPP(in_channels[-1], in_channels[-1], k=(5, 9, 13))
         elif version in ["r3.1", "r4.0"]:
             init_block = block(in_channels[-1], in_channels[-1], n=depth_gain, shortcut=False)
         else:


### PR DESCRIPTION
Close #234 

I think the optimization of the `SPP` module should be done in the downstream framework, and we should keep the parts of PyTorch simple, so let's revert the `SPPF` to `SPP`.