### PR TITLE
Remove low scoring filter from LogitsDecoder

### DIFF
--- a/test/test_relaying.py
+++ b/test/test_relaying.py
@@ -1,10 +1,7 @@
-import pytest
-import torch
-from torch import Tensor
+# Copyright (c) 2021, yolort team. All Rights Reserved.
 from torch.jit._trace import TopLevelTracedModule
 from yolort.models import yolov5s
-from yolort.relaying import get_trace_module, YOLOInference
-from yolort.v5 import attempt_download
+from yolort.relaying import get_trace_module
 
 
 def test_get_trace_module():
@@ -12,33 +9,3 @@ def test_get_trace_module():
     script_module = get_trace_module(model_func, input_shape=(416, 320))
     assert isinstance(script_module, TopLevelTracedModule)
     assert script_module.code is not None
-
-
-@pytest.mark.parametrize(
-    "arch, version, upstream_version, hash_prefix",
-    [
-        ("yolov5s", "r4.0", "v4.0", "9ca9a642"),
-        ("yolov5n", "r6.0", "v6.0", "649e089f"),
-        ("yolov5s", "r6.0", "v6.0", "c3b140f3"),
-        ("yolov5n6", "r6.0", "v6.0", "beecbbae"),
-    ],
-)
-def test_yolo_inference(arch, version, upstream_version, hash_prefix):
-
-    base_url = "https://github.com/ultralytics/yolov5/releases/download/"
-    model_url = f"{base_url}/{upstream_version}/{arch}.pt"
-    checkpoint_path = attempt_download(model_url)
-    score_thresh = 0.25
-
-    model = YOLOInference(
-        checkpoint_path,
-        score_thresh=score_thresh,
-        version=version,
-    )
-    model.eval()
-    samples = torch.rand(1, 3, 320, 320)
-    outs = model(samples)
-
-    assert isinstance(outs[0], dict)
-    assert isinstance(outs[0]["boxes"], Tensor)
-    assert isinstance(outs[0]["scores"], Tensor)

--- a/test/test_relaying.py
+++ b/test/test_relaying.py
@@ -41,5 +41,4 @@ def test_yolo_inference(arch, version, upstream_version, hash_prefix):
 
     assert isinstance(outs[0], dict)
     assert isinstance(outs[0]["boxes"], Tensor)
-    assert isinstance(outs[0]["labels"], Tensor)
     assert isinstance(outs[0]["scores"], Tensor)

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021, yolort team. All Rights Reserved.
 from pathlib import Path
+
 import pytest
 import torch
 from torch import Tensor

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2021, yolort team. All Rights Reserved.
+from pathlib import Path
 import pytest
 import torch
 from torch import Tensor
@@ -34,3 +35,29 @@ def test_yolo_trt_module(arch, version, upstream_version, hash_prefix):
     assert isinstance(outs[0], dict)
     assert isinstance(outs[0]["boxes"], Tensor)
     assert isinstance(outs[0]["scores"], Tensor)
+
+
+@pytest.mark.parametrize(
+    "arch, version, upstream_version, hash_prefix",
+    [
+        ("yolov5s", "r4.0", "v4.0", "9ca9a642"),
+        ("yolov5n", "r6.0", "v6.0", "649e089f"),
+        ("yolov5s", "r6.0", "v6.0", "c3b140f3"),
+        ("yolov5n6", "r6.0", "v6.0", "beecbbae"),
+    ],
+)
+def test_trt_model_onnx_saves(arch, version, upstream_version, hash_prefix):
+    base_url = "https://github.com/ultralytics/yolov5/releases/download/"
+    model_url = f"{base_url}/{upstream_version}/{arch}.pt"
+    checkpoint_path = attempt_download(model_url, hash_prefix=hash_prefix)
+    score_thresh = 0.25
+
+    model = YOLOTRTModule(
+        checkpoint_path,
+        score_thresh=score_thresh,
+        version=version,
+    )
+    model.eval()
+    onnx_file_path = f"trt_model_onnx_saves_{arch}_{hash_prefix}.onnx"
+    model.to_onnx(onnx_file_path)
+    assert Path(onnx_file_path).exists()

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2021, yolort team. All Rights Reserved.
+import pytest
+import torch
+from torch import Tensor
+from yolort.runtime import YOLOTRTModule
+from yolort.v5 import attempt_download
+
+
+@pytest.mark.parametrize(
+    "arch, version, upstream_version, hash_prefix",
+    [
+        ("yolov5s", "r4.0", "v4.0", "9ca9a642"),
+        ("yolov5n", "r6.0", "v6.0", "649e089f"),
+        ("yolov5s", "r6.0", "v6.0", "c3b140f3"),
+        ("yolov5n6", "r6.0", "v6.0", "beecbbae"),
+    ],
+)
+def test_yolo_trt_module(arch, version, upstream_version, hash_prefix):
+
+    base_url = "https://github.com/ultralytics/yolov5/releases/download/"
+    model_url = f"{base_url}/{upstream_version}/{arch}.pt"
+    checkpoint_path = attempt_download(model_url, hash_prefix=hash_prefix)
+    score_thresh = 0.25
+
+    model = YOLOTRTModule(
+        checkpoint_path,
+        score_thresh=score_thresh,
+        version=version,
+    )
+    model.eval()
+    samples = torch.rand(1, 3, 320, 320)
+    outs = model(samples)
+
+    assert isinstance(outs[0], dict)
+    assert isinstance(outs[0]["boxes"], Tensor)
+    assert isinstance(outs[0]["scores"], Tensor)

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -60,5 +60,6 @@ def test_trt_model_onnx_saves(arch, version, upstream_version, hash_prefix):
     )
     model.eval()
     onnx_file_path = f"trt_model_onnx_saves_{arch}_{hash_prefix}.onnx"
+    assert not Path(onnx_file_path).exists()
     model.to_onnx(onnx_file_path)
     assert Path(onnx_file_path).exists()

--- a/yolort/relaying/__init__.py
+++ b/yolort/relaying/__init__.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2021, Zhiqiang Wang. All Rights Reserved.
+# Copyright (c) 2021, yolort team. All Rights Reserved.
 from .trace_wrapper import get_trace_module
-from .yolo_inference import YOLOInference
 
-__all__ = ["get_trace_module", "YOLOInference"]
+__all__ = ["get_trace_module"]

--- a/yolort/runtime/__init__.py
+++ b/yolort/runtime/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2021, yolort team. All Rights Reserved.
 from .ort_modeling import PredictorORT
+from .yolo_tensorrt_model import YOLOTRTModule
 
-__all__ = ["PredictorORT"]
+__all__ = ["PredictorORT", "YOLOTRTModule"]

--- a/yolort/runtime/yolo_tensorrt_model.py
+++ b/yolort/runtime/yolo_tensorrt_model.py
@@ -1,8 +1,7 @@
 # Copyright (c) 2021, yolort team. All Rights Reserved.
-from pytorch_lightning import LightningModule
 import torch
+from pytorch_lightning import LightningModule
 from torch import Tensor
-
 from yolort.models import YOLO
 from yolort.models.box_head import LogitsDecoder
 

--- a/yolort/runtime/yolo_tensorrt_model.py
+++ b/yolort/runtime/yolo_tensorrt_model.py
@@ -64,7 +64,7 @@ class YOLOTRTModule(nn.Module):
             **kwargs: Will be passed to torch.onnx.export function.
         """
         if input_sample is None:
-            input_sample = torch.rand(1, 3, 320, 320)
+            input_sample = torch.rand(1, 3, 320, 320).to(next(self.parameters()).device)
 
         dynamic_axes = (
             {

--- a/yolort/runtime/yolo_tensorrt_model.py
+++ b/yolort/runtime/yolo_tensorrt_model.py
@@ -1,14 +1,15 @@
 # Copyright (c) 2021, yolort team. All Rights Reserved.
 import torch
-from pytorch_lightning import LightningModule
-from torch import Tensor
+from pathlib import Path
+from torch import nn, Tensor
+from typing import Dict, List, Optional, Union
 from yolort.models import YOLO
 from yolort.models.box_head import LogitsDecoder
 
 __all__ = ["YOLOTRTModule"]
 
 
-class YOLOTRTModule(LightningModule):
+class YOLOTRTModule(nn.Module):
     """
     TensorRT deployment friendly wrapper for YOLO.
 
@@ -32,7 +33,7 @@ class YOLOTRTModule(LightningModule):
         )
 
     @torch.no_grad()
-    def forward(self, inputs: Tensor):
+    def forward(self, inputs: Tensor) -> List[Dict[str, Tensor]]:
         """
         Args:
             inputs (Tensor): batched images, of shape [batch_size x 3 x H x W]
@@ -41,3 +42,46 @@ class YOLOTRTModule(LightningModule):
         outputs = self.model(inputs)
 
         return outputs
+
+    @torch.no_grad()
+    def to_onnx(
+        self,
+        file_path: Union[str, Path],
+        input_sample: Optional[Tensor] = None,
+        opset_version: int = 11,
+        enable_dynamic: bool = True,
+        **kwargs,
+    ):
+        """
+        Saves the model in ONNX format.
+
+        Args:
+            file_path: The path of the file the onnx model should be saved to.
+            input_sample: An input for tracing. Default: None.
+            opset_version: Opset version we export the model to the onnx submodule. Default: 11.
+            enable_dynamic: Whether to specify axes of tensors as dynamic. Default: True.
+            **kwargs: Will be passed to torch.onnx.export function.
+        """
+        if input_sample is None:
+            input_sample = torch.rand(1, 3, 320, 320)
+
+        dynamic_axes = {
+            "images_tensors": {0: "batch", 2: "height", 3: "width"},
+            "boxes": {0: "batch", 1: "num_objects"},
+            "scores": {0: "batch", 1: "num_objects"},
+        } if enable_dynamic else None
+
+        input_names = ["images_tensors"]
+        output_names = ["boxes", "scores"]
+
+        torch.onnx.export(
+            self.model,
+            input_sample,
+            file_path,
+            do_constant_folding=True,
+            opset_version=opset_version,
+            input_names=input_names,
+            output_names=output_names,
+            dynamic_axes=dynamic_axes,
+            **kwargs,
+        )

--- a/yolort/runtime/yolo_tensorrt_model.py
+++ b/yolort/runtime/yolo_tensorrt_model.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2021, yolort team. All Rights Reserved.
-import torch
 from pathlib import Path
-from torch import nn, Tensor
 from typing import Dict, List, Optional, Union
+
+import torch
+from torch import nn, Tensor
 from yolort.models import YOLO
 from yolort.models.box_head import LogitsDecoder
 
@@ -65,11 +66,15 @@ class YOLOTRTModule(nn.Module):
         if input_sample is None:
             input_sample = torch.rand(1, 3, 320, 320)
 
-        dynamic_axes = {
-            "images_tensors": {0: "batch", 2: "height", 3: "width"},
-            "boxes": {0: "batch", 1: "num_objects"},
-            "scores": {0: "batch", 1: "num_objects"},
-        } if enable_dynamic else None
+        dynamic_axes = (
+            {
+                "images_tensors": {0: "batch", 2: "height", 3: "width"},
+                "boxes": {0: "batch", 1: "num_objects"},
+                "scores": {0: "batch", 1: "num_objects"},
+            }
+            if enable_dynamic
+            else None
+        )
 
         input_names = ["images_tensors"]
         output_names = ["boxes", "scores"]

--- a/yolort/runtime/yolo_tensorrt_model.py
+++ b/yolort/runtime/yolo_tensorrt_model.py
@@ -1,15 +1,17 @@
-# Copyright (c) 2021, Zhiqiang Wang. All Rights Reserved.
+# Copyright (c) 2021, yolort team. All Rights Reserved.
+from pytorch_lightning import LightningModule
 import torch
-from torch import nn, Tensor
+from torch import Tensor
+
 from yolort.models import YOLO
 from yolort.models.box_head import LogitsDecoder
 
-__all__ = ["YOLOInference"]
+__all__ = ["YOLOTRTModule"]
 
 
-class YOLOInference(nn.Module):
+class YOLOTRTModule(LightningModule):
     """
-    A deployment friendly wrapper of YOLO.
+    TensorRT deployment friendly wrapper for YOLO.
 
     Remove the ``torchvision::nms`` in this warpper, due to the fact that some third-party
     inference frameworks currently do not support this operator very well.


### PR DESCRIPTION
This is a follow-up PR of #238 to make the exported ONNX model can be worked on TensorRT.

```python
import torch
from torch import Tensor
from yolort.runtime import YOLOTRTModule
from yolort.v5 import attempt_download

model_path = "yolov5n.pt"
checkpoint_path = attempt_download(model_path)

model = YOLOTRTModule(checkpoint_path, score_thresh=score_thresh)
model.eval()
samples = torch.rand(1, 3, 320, 320)
outs = model(samples)

assert isinstance(outs[0], dict)
assert isinstance(outs[0]["boxes"], Tensor)
assert isinstance(outs[0]["scores"], Tensor)

model.to_onnx("yolov5n.onnx")
```