### PR TITLE
Fix register_nms in `YOLOGraphSurgeon`

### DIFF
--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 import torch
 from torch import Tensor
-from yolort.runtime import YOLOTRTModule
+from yolort.runtime.yolo_tensorrt_model import YOLOTRTModule
 from yolort.v5 import attempt_download
 
 

--- a/yolort/models/box_head.py
+++ b/yolort/models/box_head.py
@@ -401,7 +401,12 @@ class LogitsDecoder(nn.Module):
             bbox_regression.append(boxes)
             pred_scores.append(scores)
 
-        return torch.stack(bbox_regression), torch.stack(pred_scores)
+        # The default boxes tensor has shape [batch_size, number_boxes, 4].
+        # This will insert a "1" dimension in the second axis, to become
+        # [batch_size, number_boxes, 1, 4], the shape that plugin/BatchedNMS expects.
+        boxes = torch.stack(bbox_regression).unsqueeze_(2)
+        scores = torch.stack(pred_scores)
+        return boxes, scores
 
 
 class PostProcess(LogitsDecoder):

--- a/yolort/runtime/__init__.py
+++ b/yolort/runtime/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2021, yolort team. All Rights Reserved.
 from .y_onnxruntime import PredictorORT
 from .y_tensorrt import PredictorTRT
-from .yolo_tensorrt_model import YOLOTRTModule
+from .yolo_graphsurgeon import YOLOGraphSurgeon
 
-__all__ = ["PredictorORT", "YOLOTRTModule", "PredictorTRT"]
+__all__ = ["PredictorORT", "PredictorTRT", "YOLOGraphSurgeon"]

--- a/yolort/runtime/trt_helper.py
+++ b/yolort/runtime/trt_helper.py
@@ -78,7 +78,7 @@ class EngineBuilder:
     def create_engine(
         self,
         engine_path: str,
-        precision: str,
+        precision: str = "fp32",
         calib_input: Optional[str] = None,
         calib_cache: Optional[str] = None,
         calib_num_images: int = 5000,

--- a/yolort/runtime/y_tensorrt.py
+++ b/yolort/runtime/y_tensorrt.py
@@ -95,9 +95,11 @@ class PredictorTRT:
         assert image.shape == self.bindings["images"].shape, (image.shape, self.bindings["images"].shape)
         self.binding_addrs["images"] = int(image.data_ptr())
         self.context.execute_v2(list(self.binding_addrs.values()))
-        boxes = self.bindings["boxes"].data
-        scores = self.bindings["scores"].data
-        return boxes, scores
+        num_dets = self.bindings["num_detections"].data
+        boxes = self.bindings["detection_boxes"].data
+        scores = self.bindings["detection_scores"].data
+        labels = self.bindings["detection_classes"].data
+        return num_dets, boxes, scores, labels
 
     def run_on_image(self, image):
         """

--- a/yolort/runtime/y_tensorrt.py
+++ b/yolort/runtime/y_tensorrt.py
@@ -11,7 +11,6 @@ from typing import Dict, List
 import numpy as np
 import torch
 from torch import Tensor
-from torchvision.ops import boxes as box_ops
 
 try:
     import tensorrt as trt

--- a/yolort/runtime/y_tensorrt.py
+++ b/yolort/runtime/y_tensorrt.py
@@ -66,6 +66,7 @@ class PredictorTRT:
     def _build_engine(self):
         logger.info(f"Loading {self.engine_path} for TensorRT inference...")
         trt_logger = trt.Logger(trt.Logger.INFO)
+        trt.init_libnvinfer_plugins(trt_logger, namespace="")
         with open(self.engine_path, "rb") as f, trt.Runtime(trt_logger) as runtime:
             engine = runtime.deserialize_cuda_engine(f.read())
 

--- a/yolort/runtime/yolo_graphsurgeon.py
+++ b/yolort/runtime/yolo_graphsurgeon.py
@@ -24,11 +24,11 @@ except ImportError:
 from .yolo_tensorrt_model import YOLOTRTModule
 
 logging.basicConfig(level=logging.INFO)
-logging.getLogger("YOLOv5GraphSurgeon").setLevel(logging.INFO)
-log = logging.getLogger("YOLOv5GraphSurgeon")
+logging.getLogger("YOLOGraphSurgeon").setLevel(logging.INFO)
+logger = logging.getLogger("YOLOGraphSurgeon")
 
 
-class YOLOv5GraphSurgeon:
+class YOLOGraphSurgeon:
     """
     Constructor of the YOLOv5 Graph Surgeon object, TensorRT treat ``nms`` as
     plugin, especially ``EfficientNMS_TRT`` in our yolort PostProcess module.
@@ -44,7 +44,6 @@ class YOLOv5GraphSurgeon:
     def __init__(
         self,
         checkpoint_path: str,
-        score_thresh: float = 0.25,
         version: str = "r6.0",
         enable_dynamic: bool = True,
     ):
@@ -52,19 +51,19 @@ class YOLOv5GraphSurgeon:
         assert checkpoint_path.exists()
 
         # Use YOLOTRTModule to convert saved model to an initial ONNX graph.
-        model = YOLOTRTModule(checkpoint_path, score_thresh=score_thresh, version=version)
+        model = YOLOTRTModule(checkpoint_path, version=version)
         model = model.eval()
 
-        log.info(f"Loaded saved model from {checkpoint_path}")
+        logger.info(f"Loaded saved model from {checkpoint_path}")
         onnx_model_path = checkpoint_path.with_suffix(".onnx")
         model.to_onnx(onnx_model_path, enable_dynamic=enable_dynamic)
         self.graph = gs.import_onnx(onnx.load(onnx_model_path))
         assert self.graph
-        log.info("PyTorch2ONNX graph created successfully")
+        logger.info("PyTorch2ONNX graph created successfully")
 
         # Fold constants via ONNX-GS that PyTorch2ONNX may have missed
         self.graph.fold_constants()
-
+        self.num_classes = model.num_clases
         self.batch_size = 1
 
     def infer(self):
@@ -85,11 +84,11 @@ class YOLOv5GraphSurgeon:
                 model = shape_inference.infer_shapes(model)
                 self.graph = gs.import_onnx(model)
             except Exception as e:
-                log.info(f"Shape inference could not be performed at this time:\n{e}")
+                logger.info(f"Shape inference could not be performed at this time:\n{e}")
             try:
                 self.graph.fold_constants(fold_shapes=True)
             except TypeError as e:
-                log.error(
+                logger.error(
                     "This version of ONNX GraphSurgeon does not support folding shapes, "
                     f"please upgrade your onnx_graphsurgeon module. Error:\n{e}"
                 )
@@ -111,13 +110,14 @@ class YOLOv5GraphSurgeon:
         self.graph.cleanup().toposort()
         model = gs.export_onnx(self.graph)
         onnx.save(model, output_path)
-        log.info(f"Saved ONNX model to {output_path}")
+        logger.info(f"Saved ONNX model to {output_path}")
 
     def register_nms(
         self,
         score_thresh: float = 0.25,
         nms_thresh: float = 0.45,
         detections_per_img: int = 100,
+        normalized: bool = True,
     ):
         """
         Register the ``EfficientNMS_TRT`` plugin node.
@@ -139,15 +139,18 @@ class YOLOv5GraphSurgeon:
         self.infer()
         # Find the concat node at the end of the network
         nms_inputs = self.graph.outputs
-        op = "EfficientNMS_TRT"
+        op = "BatchedNMS_TRT"
         attrs = {
             "plugin_version": "1",
-            "background_class": -1,  # no background class
-            "max_output_boxes": detections_per_img,
-            "score_threshold": max(0.01, score_thresh),
-            "iou_threshold": nms_thresh,
-            "score_activation": True,
-            "box_coding": 0,
+            'shareLocation': True,
+            'backgroundLabelId': -1,  # no background class
+            'numClasses': self.num_classes,
+            'topK': 1024,
+            'keepTopK': detections_per_img,
+            'scoreThreshold': score_thresh,
+            'iouThreshold': nms_thresh,
+            'isNormalized': normalized,
+            'clipBoxes': False,
         }
 
         # NMS Outputs
@@ -167,8 +170,8 @@ class YOLOv5GraphSurgeon:
             shape=[self.batch_size, detections_per_img],
         )
         output_labels = gs.Variable(
-            name="detection_labels",
-            dtype=np.int32,
+            name="detection_classes",
+            dtype=np.float32,
             shape=[self.batch_size, detections_per_img],
         )
 
@@ -183,7 +186,7 @@ class YOLOv5GraphSurgeon:
             outputs=nms_outputs,
             attrs=attrs,
         )
-        log.info(f"Created NMS plugin '{op}' with attributes: {attrs}")
+        logger.info(f"Created NMS plugin '{op}' with attributes: {attrs}")
 
         self.graph.outputs = nms_outputs
 

--- a/yolort/runtime/yolo_graphsurgeon.py
+++ b/yolort/runtime/yolo_graphsurgeon.py
@@ -120,20 +120,19 @@ class YOLOGraphSurgeon:
         normalized: bool = True,
     ):
         """
-        Register the ``EfficientNMS_TRT`` plugin node.
+        Register the ``BatchedNMS_TRT`` plugin node.
 
         NMS expects these shapes for its input tensors:
-        - box_net: [batch_size, number_boxes, 4]
-        - class_net: [batch_size, number_boxes, number_labels]
-
-        As the original tensors from YOLOv5 will be used, the NMS code type is set to 0 (Corners),
-        because this is the internal box coding format used by the network.
+            - box_net: [batch_size, number_boxes, 1, 4]
+            - class_net: [batch_size, number_boxes, number_labels]
 
         Args:
-            threshold: Override the score threshold attribute. If set to None,
-                use the value in the graph.
-            detections: Override the max detections attribute. If set to None,
-                use the value in the graph.
+            score_thresh (float): The scalar threshold for score (low scoring boxes are removed).
+            nms_thresh (float): The scalar threshold for IOU (new boxes that have high IOU
+                overlap with previously selected boxes are removed).
+            detections_per_img (int): Number of best detections to keep after NMS.
+            normalized (bool): Set to false if the box coordinates are not normalized,
+                meaning they are not in the range [0,1]. Defaults: True.
         """
 
         self.infer()

--- a/yolort/runtime/yolo_graphsurgeon.py
+++ b/yolort/runtime/yolo_graphsurgeon.py
@@ -141,15 +141,15 @@ class YOLOGraphSurgeon:
         op = "BatchedNMS_TRT"
         attrs = {
             "plugin_version": "1",
-            'shareLocation': True,
-            'backgroundLabelId': -1,  # no background class
-            'numClasses': self.num_classes,
-            'topK': 1024,
-            'keepTopK': detections_per_img,
-            'scoreThreshold': score_thresh,
-            'iouThreshold': nms_thresh,
-            'isNormalized': normalized,
-            'clipBoxes': False,
+            "shareLocation": True,
+            "backgroundLabelId": -1,  # no background class
+            "numClasses": self.num_classes,
+            "topK": 1024,
+            "keepTopK": detections_per_img,
+            "scoreThreshold": score_thresh,
+            "iouThreshold": nms_thresh,
+            "isNormalized": normalized,
+            "clipBoxes": False,
         }
 
         # NMS Outputs

--- a/yolort/runtime/yolo_tensorrt_model.py
+++ b/yolort/runtime/yolo_tensorrt_model.py
@@ -52,6 +52,7 @@ class YOLOTRTModule(nn.Module):
 
         model.load_state_dict(model_info["state_dict"])
         self.model = model
+        self.num_clases = num_classes
 
     @torch.no_grad()
     def forward(self, inputs: Tensor) -> Tuple[Tensor, Tensor]:

--- a/yolort/runtime/yolo_tensorrt_model.py
+++ b/yolort/runtime/yolo_tensorrt_model.py
@@ -88,7 +88,7 @@ class YOLOTRTModule(nn.Module):
 
         dynamic_axes = (
             {
-                "images_tensors": {0: "batch", 2: "height", 3: "width"},
+                "images": {0: "batch", 2: "height", 3: "width"},
                 "boxes": {0: "batch", 1: "num_objects"},
                 "scores": {0: "batch", 1: "num_objects"},
             }
@@ -96,7 +96,7 @@ class YOLOTRTModule(nn.Module):
             else None
         )
 
-        input_names = ["images_tensors"]
+        input_names = ["images"]
         output_names = ["boxes", "scores"]
 
         torch.onnx.export(


### PR DESCRIPTION
Register the `BatchedNMS_TRT` plugin node at the end of `YOLOTRTModule`, and now we can get an end-to-end ONNX graph except the pre-processing.

```python
import torch
from yolort.runtime import PredictorTRT

engine_path = 'yolov5s.engine'
device = torch.device("cuda")
engine = PredictorTRT(engine_path, device)

img_path = 'bus.jpg'
image = cv2.imread(img_path)
image = engine.preprocessing(image)
detections = engine.run_on_image(image)
```