### PR TITLE
Fix TorchScript exporting for custom checkpoints

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -407,7 +407,7 @@ def test_load_from_yolov5_torchscript(
     from yolort.v5 import letterbox
 
     # Loading and pre-processing the image
-    img_path = "test/assets/bus.jpg"
+    img_path = "test/assets/zidane.jpg"
     img_raw = cv2.imread(img_path)
     img = letterbox(img_raw, new_shape=(640, 640))[0]
     img = read_image_to_tensor(img)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 from torch import Tensor
 from yolort import models
-from yolort.models import YOLOv5
+from yolort.models import YOLO, YOLOv5
 from yolort.models.anchor_utils import AnchorGenerator
 from yolort.models.backbone_utils import darknet_pan_backbone
 from yolort.models.box_head import YOLOHead, PostProcess, SetCriterion
@@ -418,18 +418,13 @@ def test_load_from_yolov5_torchscript(
 
     score_thresh = 0.25
 
-    model = YOLOv5.load_from_yolov5(
-        checkpoint_path,
-        score_thresh=score_thresh,
-        version=version,
-    )
+    model = YOLO.load_from_yolov5(checkpoint_path, score_thresh=score_thresh, version=version)
     model.eval()
     scripted_model = torch.jit.script(model)
     scripted_model.eval()
 
-    x = [img]
-    out = model(x)
-    out_script = scripted_model(x)
+    out = model(img[None])
+    out_script = scripted_model(img[None])
 
     torch.testing.assert_close(out[0]["scores"], out_script[1][0]["scores"], rtol=0, atol=0)
     torch.testing.assert_close(out[0]["labels"], out_script[1][0]["labels"], rtol=0, atol=0)

--- a/yolort/models/_utils.py
+++ b/yolort/models/_utils.py
@@ -54,7 +54,7 @@ def decode_single(
     rel_codes: Tensor,
     grid: Tensor,
     shift: Tensor,
-    stride: int,
+    stride: Tensor,
 ) -> Tuple[Tensor, Tensor]:
     """
     From a set of original boxes and encoded relative box offsets,

--- a/yolort/models/anchor_utils.py
+++ b/yolort/models/anchor_utils.py
@@ -42,8 +42,8 @@ class AnchorGenerator(nn.Module):
         device: torch.device = torch.device("cpu"),
     ) -> List[Tensor]:
 
-        anchors = torch.tensor(self.anchor_grids, dtype=dtype, device=device)
-        strides = torch.tensor(self.strides, dtype=dtype, device=device)
+        anchors = torch.as_tensor(self.anchor_grids, dtype=torch.float32, device=device).to(dtype=dtype)
+        strides = torch.as_tensor(self.strides, dtype=torch.float32, device=device).to(dtype=dtype)
         anchors = anchors.view(self.num_layers, -1, 2) / strides.view(-1, 1, 1)
 
         shifts = []

--- a/yolort/models/yolo.py
+++ b/yolort/models/yolo.py
@@ -62,10 +62,6 @@ class YOLO(nn.Module):
         - scores (``Tensor[N]``): the scores or each prediction
     """
 
-    __annotations__ = {
-        "compute_loss": SetCriterion,
-    }
-
     def __init__(
         self,
         backbone: nn.Module,
@@ -107,12 +103,7 @@ class YOLO(nn.Module):
         self.anchor_generator = anchor_generator
 
         if criterion is None:
-            criterion = SetCriterion(
-                anchor_generator.num_anchors,
-                anchor_generator.strides,
-                anchor_generator.anchor_grids,
-                num_classes,
-            )
+            criterion = SetCriterion(strides, anchor_grids, num_classes)
         self.compute_loss = criterion
 
         if head is None:

--- a/yolort/runtime/trt_helper.py
+++ b/yolort/runtime/trt_helper.py
@@ -67,8 +67,11 @@ class LogitsDecoder(nn.Module):
             shifts (List[Tensor]): Anchor shifts.
         """
         batch_size = len(head_outputs[0])
+        device = head_outputs[0].device
+        dtype = head_outputs[0].dtype
+        strides = torch.as_tensor(self.strides, dtype=torch.float32, device=device).to(dtype=dtype)
 
-        all_pred_logits = _concat_pred_logits(head_outputs, grids, shifts, self.strides)
+        all_pred_logits = _concat_pred_logits(head_outputs, grids, shifts, strides)
 
         bbox_regression = []
         pred_scores = []


### PR DESCRIPTION
An example to export the torchscript for the checkpoint trained with ultralytics/yolov5:

```python
import cv2
import torch
from yolort.models import YOLO
from yolort.utils import read_image_to_tensor
from yolort.v5 import letterbox, attempt_download

# Loading and pre-processing the image
img_path = "test/assets/zidane.jpg"
img_raw = cv2.imread(img_path)
img = letterbox(img_raw, new_shape=(640, 640))[0]
img = read_image_to_tensor(img)

# will yolov5n6.pt from 'https://github.com/ultralytics/yolov5/releases/download/v6.0/yolov5n6.pt'
checkpoint_path = attempt_download("yolov5n6.pt")

model = YOLO.load_from_yolov5(checkpoint_path, score_thresh=0.25)
model.eval()
# Script the model
scripted_model = torch.jit.script(model)
scripted_model.eval()

x = img[None]
out = model(x)
out_script = scripted_model(x)

torch.testing.assert_close(out[0]["scores"], out_script[1][0]["scores"], rtol=0, atol=0)
torch.testing.assert_close(out[0]["labels"], out_script[1][0]["labels"], rtol=0, atol=0)
torch.testing.assert_close(out[0]["boxes"], out_script[1][0]["boxes"], rtol=0, atol=0)
```

cc @mattpopovich , this will fix #265 .