### PR TITLE
Fix a bug and document RandomZoomOut

### DIFF
--- a/yolort/data/transforms.py
+++ b/yolort/data/transforms.py
@@ -203,7 +203,7 @@ class RandomZoomOut(nn.Module):
             elif image.ndimension() == 2:
                 image = image.unsqueeze(0)
 
-        if torch.rand(1) < self.p:
+        if torch.rand(1) >= self.p:
             return image, target
 
         orig_w, orig_h = get_image_size(image)
@@ -225,6 +225,7 @@ class RandomZoomOut(nn.Module):
 
         image = F.pad(image, [left, top, right, bottom], fill=fill)
         if isinstance(image, Tensor):
+            # PyTorch's pad supports only integers on fill. So we need to overwrite the colour
             v = torch.tensor(self.fill, device=image.device, dtype=image.dtype).view(-1, 1, 1)
             image[..., :top, :] = image[..., :, :left] = image[..., (top + orig_h) :, :] = image[
                 ..., :, (left + orig_w) :


### PR DESCRIPTION
Ported from https://github.com/pytorch/vision/pull/5278

We found a bug on the original implementation of `RandomZoomOut` from TorchVision, so I thought to patch this copy as well. The good news is that we plan soon to move these transforms in TorchVision main library (using the new Transforms API) so you won't have to maintain them in your repo. But until then, this will do.