### PR TITLE
Support multiple batches for exporting ONNX with pre-processing

### DIFF
--- a/test/test_runtime_ort.py
+++ b/test/test_runtime_ort.py
@@ -29,7 +29,8 @@ class TestONNXExporter:
         onnx_io = io.BytesIO()
 
         # export to onnx models
-        export_onnx(onnx_io, model=model, opset_version=_onnx_opset_version)
+        batch_size = len(inputs_list[0])
+        export_onnx(onnx_io, model=model, opset_version=_onnx_opset_version, batch_size=batch_size)
 
         # validate the exported model with onnx runtime
         for test_inputs in inputs_list:
@@ -65,35 +66,52 @@ class TestONNXExporter:
         return image
 
     def get_test_images(self):
-        return [self.get_image("bus.jpg")], [self.get_image("zidane.jpg")]
+        return self.get_image("bus.jpg"), self.get_image("zidane.jpg")
 
     @pytest.mark.parametrize(
         "arch, fixed_size, upstream_version",
         [
-            ("yolov5s", False, "r3.1"),
-            ("yolov5m", True, "r4.0"),
+            ("yolov5s", True, "r3.1"),
             ("yolov5m", False, "r4.0"),
             ("yolov5n", True, "r6.0"),
             ("yolov5n", False, "r6.0"),
-            ("yolov5n6", True, "r6.0"),
             ("yolov5n6", False, "r6.0"),
         ],
     )
-    def test_onnx_export(self, arch, fixed_size, upstream_version):
-        images_one, images_two = self.get_test_images()
-        images_dummy = [torch.ones(3, 1080, 720) * 0.3]
+    def test_onnx_export_single_image(self, arch, fixed_size, upstream_version):
+        img_one, img_two = self.get_test_images()
+        img_dummy = torch.ones(3, 1080, 720) * 0.3
 
+        size = (640, 640) if arch[-1] == "6" else (320, 320)
         model = models.__dict__[arch](
             upstream_version=upstream_version,
             pretrained=True,
-            size=(640, 640),
-            fixed_shape=(640, 640) if fixed_size else None,
+            size=size,
+            fixed_shape=size if fixed_size else None,
             score_thresh=0.45,
         )
         model = model.eval()
-        model(images_one)
+        model([img_one])
         # Test exported model on images of different size, or dummy input
-        self.run_model(model, [(images_one,), (images_two,), (images_dummy,)])
+        self.run_model(model, [[img_one], [img_two], [img_dummy]])
 
-        # Test exported model for an image with no detections on other images
-        self.run_model(model, [(images_dummy,), (images_one,)])
+    @pytest.mark.parametrize("arch", ["yolov5n6"])
+    def test_onnx_export_multi_batches(self, arch):
+        img_one, img_two = self.get_test_images()
+        img_dummy = torch.ones(3, 1080, 720) * 0.3
+
+        size = (640, 640) if arch[-1] == "6" else (320, 320)
+        model = models.__dict__[arch](pretrained=True, size=size, score_thresh=0.45)
+        model = model.eval()
+        model([img_one, img_two])
+
+        # Test exported model on images of different size, or dummy input
+        inputs_list = [
+            [img_one, img_two],
+            [img_two, img_one],
+            [img_dummy, img_one],
+            [img_one, img_one],
+            [img_two, img_dummy],
+            [img_dummy, img_two],
+        ]
+        self.run_model(model, inputs_list=inputs_list)

--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -50,8 +50,8 @@ def get_parser():
         default=[640, 640],
         help="Image size for inferencing (default: 640, 640).",
     )
-    parser.add_argument("--size_divisible", type=int, default=32, help="Stride for the preprocessing.")
-    parser.add_argument("--batch_size", default=1, type=int, help="Batch size for YOLOv5.")
+    parser.add_argument("--size_divisible", type=int, default=32, help="Stride for pre-processing.")
+    parser.add_argument("--batch_size", default=1, type=int, help="Batch size for pre-processing.")
     parser.add_argument("--opset", default=11, type=int, help="Opset version for exporing ONNX models")
     parser.add_argument("--simplify", action="store_true", help="ONNX: simplify model.")
 
@@ -79,6 +79,7 @@ def cli_main():
         version=args.version,
         skip_preprocess=args.skip_preprocess,
         opset_version=args.opset,
+        batch_size=args.batch_size,
     )
 
 

--- a/yolort/runtime/ort_helper.py
+++ b/yolort/runtime/ort_helper.py
@@ -186,8 +186,10 @@ class ONNXBuilder:
     def _set_input_sample(self):
         if self._skip_preprocess:
             return torch.rand(1, 3, 640, 640)
-        else:
-            return [torch.rand(3, 640, 640)] * 2
+        if self._batch_size == 1:
+            return [torch.rand(3, 640, 640)]
+
+        return [torch.rand(3, 640, 640)] * self._batch_size
 
     @torch.no_grad()
     def to_onnx(self, onnx_path: str, **kwargs):

--- a/yolort/runtime/ort_helper.py
+++ b/yolort/runtime/ort_helper.py
@@ -146,7 +146,10 @@ class ONNXBuilder:
         if self._batch_size == 1:
             return ["image"]
 
-        return ["images1", "images2"]
+        input_names = []
+        for i in range(self._batch_size):
+            input_names.append(f"image{i + 1}")
+        return input_names
 
     def _set_output_names(self):
         if self._skip_preprocess:
@@ -154,7 +157,10 @@ class ONNXBuilder:
         if self._batch_size == 1:
             return ["score", "label", "box"]
 
-        return ["scores1", "labels1", "boxes1", "scores2", "labels2", "boxes2"]
+        output_names = []
+        for i in range(self._batch_size):
+            output_names.extend([f"score{i + 1}", f"label{i + 1}", f"box{i + 1}"])
+        return output_names
 
     def _set_dynamic_axes(self):
         if self._skip_preprocess:
@@ -172,16 +178,13 @@ class ONNXBuilder:
                 "score": {0: "num_objects"},
             }
 
-        return {
-            "images1": {1: "height", 2: "width"},
-            "images2": {1: "height", 2: "width"},
-            "boxes1": {0: "num_objects"},
-            "labels1": {0: "num_objects"},
-            "scores1": {0: "num_objects"},
-            "boxes2": {0: "num_objects"},
-            "labels2": {0: "num_objects"},
-            "scores2": {0: "num_objects"},
-        }
+        dynamic_axes = {}
+        for i in range(self._batch_size):
+            dynamic_axes[f"image{i + 1}"] = {1: "height", 2: "width"}
+            dynamic_axes[f"box{i + 1}"] = {0: "num_objects"}
+            dynamic_axes[f"label{i + 1}"] = {0: "num_objects"}
+            dynamic_axes[f"score{i + 1}"] = {0: "num_objects"}
+        return dynamic_axes
 
     def _set_input_sample(self):
         if self._skip_preprocess:


### PR DESCRIPTION
The `batch-size` argument / parameter is only used for models that include pre-processing. You need to specify the batch sizes and ensure that the number of input images is the same as the batches when inferring if you want to export multiple batches ONNX models.