### PR TITLE
Enhance `PredictorORT` to adapt to more scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ______________________________________________________________________
 
 ## 🤗 Introduction
 
-**What it is.** Yet another implementation of Ultralytics's [YOLOv5](https://github.com/ultralytics/yolov5). `yolort` aims to make the training and inference of the object detection integrate more seamlessly together. `yolort` now adopts the same model structure as the official YOLOv5. The significant difference is that we adopt the dynamic shape mechanism, and within this, we can embed both pre-processing (`letterbox`) and post-processing (`nms`) into the model graph, which simplifies the deployment strategy. In this sense, `yolort` makes it possible to be deployed more friendly on `LibTorch`, `ONNX Runtime`, `TVM` , `TensorRT`and so on.
+**What it is.** Yet another implementation of Ultralytics's [YOLOv5](https://github.com/ultralytics/yolov5). `yolort` aims to make the training and inference of the object detection integrate more seamlessly together. `yolort` now adopts the same model structure as the official YOLOv5. The significant difference is that we adopt the dynamic shape mechanism, and within this, we can embed both pre-processing (`letterbox`) and post-processing (`nms`) into the model graph, which simplifies the deployment strategy. In this sense, `yolort` makes it possible to be deployed more friendly on `LibTorch`, `ONNX Runtime`, `TVM`, `TensorRT`and so on.
 
 **About the code.** Follow the design principle of [detr](https://github.com/facebookresearch/detr):
 
@@ -133,7 +133,20 @@ We provide a [tutorial](https://zhiqwang.com/yolov5-rt-stack/notebooks/inference
 
 ### Inference on ONNX Runtime backend
 
-On the `ONNX Runtime` front you can use the [C++ example](deployment/onnxruntime), and we also provide a [tutorial](https://zhiqwang.com/yolov5-rt-stack/notebooks/export-onnx-inference-onnxruntime.html) for using the `ONNX Runtime`.
+We provide a pipeline for deploying yolort with ONNX Runtime.
+
+```python
+from yolort.runtime import PredictorORT
+
+# Load the serialized ONNX model
+engine_path = "yolov5n6.onnx"
+y_runtime = PredictorORT(engine_path, device="cpu")
+
+# Perform inference on an image file
+predictions = y_runtime.predict("bus.jpg")
+```
+
+Please check out this [tutorial](https://zhiqwang.com/yolov5-rt-stack/notebooks/export-onnx-inference-onnxruntime.html) to use yolort's ONNX model conversion and ONNX Runtime inferencing. And you can use the [example](deployment/onnxruntime) for ONNX Runtime C++ interface.
 
 ### Inference on TensorRT backend
 
@@ -143,7 +156,7 @@ The pipeline for TensorRT deployment is also very easy to use.
 import torch
 from yolort.runtime import PredictorTRT
 
-# Load the exported TensorRT engine
+# Load the serialized TensorRT engine
 engine_path = "yolov5n6.engine"
 device = torch.device("cuda")
 y_runtime = PredictorTRT(engine_path, device=device)
@@ -152,7 +165,7 @@ y_runtime = PredictorTRT(engine_path, device=device)
 predictions = y_runtime.predict("bus.jpg")
 ```
 
-On the `TensorRT` front you can use the [C++ example](deployment/tensorrt), and we also provide a [tutorial](https://zhiqwang.com/yolov5-rt-stack/notebooks/onnx-graphsurgeon-inference-tensorrt.html) for using the `TensorRT`.
+Besides, we provide a [tutorial](https://zhiqwang.com/yolov5-rt-stack/notebooks/onnx-graphsurgeon-inference-tensorrt.html) detailing yolort's model conversion to TensorRT and the use of the Python interface. Please check this [example](deployment/tensorrt) if you want to use the C++ interface.
 
 ## 🎨 Model Graph Visualization
 
@@ -172,7 +185,7 @@ If you use yolort in your publication, please cite it by using the following Bib
 
 ```bibtex
 @Misc{yolort2021,
-  author =       {Zhiqiang Wang, Shiquan Yu, Fidan Kharrasov},
+  author =       {Zhiqiang Wang and Shiquan Yu and Fidan Kharrasov},
   title =        {yolort: A runtime stack for object detection on specialized accelerators},
   howpublished = {\url{https://github.com/zhiqwang/yolov5-rt-stack}},
   year =         {2021}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ______________________________________________________________________
 
 ## 🤗 Introduction
 
-**What it is.** Yet another implementation of Ultralytics's [YOLOv5](https://github.com/ultralytics/yolov5). `yolort` aims to make the training and inference of the object detection integrate more seamlessly together. `yolort` now adopts the same model structure as the official YOLOv5. The significant difference is that we adopt the dynamic shape mechanism, and within this, we can embed both pre-processing (`letterbox`) and post-processing (`nms`) into the model graph, which simplifies the deployment strategy. In this sense, `yolort` makes it possible to be deployed more friendly on `LibTorch`, `ONNX Runtime`, `TVM`, `TensorRT`and so on.
+**What it is.** Yet another implementation of Ultralytics's [YOLOv5](https://github.com/ultralytics/yolov5). yolort aims to make the training and inference of the object detection task integrate more seamlessly together. yolort now adopts the same model structure as the official YOLOv5. The significant difference is that we adopt the dynamic shape mechanism, and within this, we can embed both pre-processing (letterbox) and post-processing (nms) into the model graph, which simplifies the deployment strategy. In this sense, yolort makes it possible to deploy the object detection more easily and friendly on `LibTorch`, `ONNX Runtime`, `TVM`, `TensorRT` and so on.
 
 **About the code.** Follow the design principle of [detr](https://github.com/facebookresearch/detr):
 
@@ -62,7 +62,7 @@ There are no extra compiled components in `yolort` and package dependencies are 
 
 - Above all, follow the [official instructions](https://pytorch.org/get-started/locally/) to install PyTorch 1.7.0+ and torchvision 0.8.1+
 
-- Installation via Pip
+- Installation via pip
 
   Simple installation from [PyPI](https://pypi.org/project/yolort/)
 
@@ -129,7 +129,7 @@ predictions = model.predict(img_path)
 
 ### Inference on LibTorch backend
 
-We provide a [tutorial](https://zhiqwang.com/yolov5-rt-stack/notebooks/inference-pytorch-export-libtorch.html) to demonstrate how the model is transformed into `torchscript`. And we provide an [C++ example](deployment/libtorch) of how to infer with the transformed `torchscript` model.
+We provide a [tutorial](https://zhiqwang.com/yolov5-rt-stack/notebooks/inference-pytorch-export-libtorch.html) to demonstrate how the model is converted into `torchscript`. And we provide a [C++ example](deployment/libtorch) of how to do inference with the serialized `torchscript` model.
 
 ### Inference on ONNX Runtime backend
 

--- a/deployment/onnxruntime/README.md
+++ b/deployment/onnxruntime/README.md
@@ -1,13 +1,13 @@
-# ONNXRuntime Inference
+# ONNX Runtime Inference
 
-The ONNXRuntime inference for `yolort`, both GPU and CPU are supported.
+The ONNX Runtime inference for `yolort`, both CPU and GPU are supported.
 
 ## Dependencies
 
 - Ubuntu 20.04 / Windows 10 / macOS
-- ONNXRuntime 1.7 +
+- ONNX Runtime 1.7 +
 - OpenCV 4.5 +
-- CUDA 11 \[Optional\]
+- CUDA \[Optional\]
 
 *We didn't impose too strong restrictions on the versions of dependencies.*
 
@@ -21,10 +21,26 @@ The ONNX model exported by yolort differs from other pipeline in the following t
 
 ## Usage
 
-1. First, Setup the environment variable.
+1. Export your custom model to ONNX.
 
    ```bash
-   export ORT_DIR=YOUR_ONNXRUNTIME_DIR
+   python tools/export_model.py --checkpoint_path {path/to/your/best.pt} --size_divisible 32/64
+   ```
+
+   And then, you can find that a ONNX model ("best.onnx") have been generated in the directory of "best.pt". Set the `size_divisible` here according to your model, 32 for P5 ("yolov5s.pt" for instance) and 64 for P6 ("yolov5s6.pt" for instance).
+
+1. \[Optional\] Quick test with the ONNX Runtime Python interface.
+
+   ```python
+   from yolort.runtime import PredictorORT
+
+   # Load the serialized ONNX model
+   engine_path = 'yolov5n6.onnx'
+   device = 'cpu'
+   y_runtime = PredictorORT(engine_path, device=device)
+
+   # Perform inference on an image file
+   predictions = y_runtime.predict('bus.jpg')
    ```
 
 1. Compile the source code.
@@ -32,33 +48,15 @@ The ONNX model exported by yolort differs from other pipeline in the following t
    ```bash
    cd deployment/onnxruntime
    mkdir build && cd build
-   cmake .. -DONNXRUNTIME_DIR=$ORT_DIR
+   cmake .. -DONNXRUNTIME_DIR={path/to/your/ONNXRUNTIME/install/director}
    cmake --build .
-   ```
-
-1. Export your custom model to ONNX.
-
-   ```bash
-   python tools/export_model.py --checkpoint_path [path/to/your/best.pt]
-   ```
-
-   And then, you can find that a ONNX model ("best.onnx") have been generated in the directory of "best.pt".
-
-1. \[Optional\] Quick test with the ONNXRuntime Python interface.
-
-   ```python
-   from yolort.runtime import PredictorORT
-
-   detector = PredictorORT("best.onnx")
-   img_path = "bus.jpg"
-   scores, class_ids, boxes = detector.run_on_image(img_path)
    ```
 
 1. Now, you can infer your own images.
 
    ```bash
-   ./yolort_onnx [--image ../../../test/assets/zidane.jpg]
-                 [--model_path ../../../notebooks/yolov5s.onnx]
-                 [--class_names ../../../notebooks/assets/coco.names]
+   ./yolort_onnx --image ../../../test/assets/zidane.jpg
+                 --model_path ../../../notebooks/best.onnx
+                 --class_names ../../../notebooks/assets/coco.names
                  [--gpu]  # GPU switch, which is optional, and set False as default
    ```

--- a/deployment/onnxruntime/README.md
+++ b/deployment/onnxruntime/README.md
@@ -35,12 +35,12 @@ The ONNX model exported by yolort differs from other pipeline in the following t
    from yolort.runtime import PredictorORT
 
    # Load the serialized ONNX model
-   engine_path = 'yolov5n6.onnx'
-   device = 'cpu'
+   engine_path = "yolov5n6.onnx"
+   device = "cpu"
    y_runtime = PredictorORT(engine_path, device=device)
 
    # Perform inference on an image file
-   predictions = y_runtime.predict('bus.jpg')
+   predictions = y_runtime.predict("bus.jpg")
    ```
 
 1. Compile the source code.

--- a/notebooks/export-onnx-inference-onnxruntime.ipynb
+++ b/notebooks/export-onnx-inference-onnxruntime.ipynb
@@ -224,13 +224,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 44.1 s, sys: 160 ms, total: 44.3 s\n",
-      "Wall time: 1.61 s\n"
+      "The slowest run took 5.09 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+      "115 ms ± 71 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
     "with torch.no_grad():\n",
     "    model_out = model(images)"
    ]
@@ -390,7 +390,7 @@
    "source": [
     "## Inference on ONNX Runtime backend\n",
     "\n",
-    "Load the exported ONNX model."
+    "Check the version of ONNX Runtime first."
    ]
   },
   {
@@ -407,9 +407,7 @@
     }
    ],
    "source": [
-    "print(f'Starting with onnx {onnx.__version__}, onnxruntime {onnxruntime.__version__}...')\n",
-    "\n",
-    "ort_session = onnxruntime.InferenceSession(onnx_path)"
+    "print(f'Starting with onnx {onnx.__version__}, onnxruntime {onnxruntime.__version__}...')"
    ]
   },
   {
@@ -443,7 +441,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Compute onnxruntime output prediction."
+    "We provide a pipeline for deploying yolort with ONNX Runtime."
    ]
   },
   {
@@ -452,8 +450,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ort_inputs = dict((ort_session.get_inputs()[i].name, inpt) for i, inpt in enumerate(inputs))\n",
-    "ort_outs = ort_session.run(None, ort_inputs)"
+    "from yolort.runtime import PredictorORT"
    ]
   },
   {
@@ -462,17 +459,50 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Providers was initialized.\n",
+      "Set inference device to CPU\n"
+     ]
+    }
+   ],
+   "source": [
+    "y_runtime = PredictorORT(onnx_path, device=\"cpu\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ort_outs1 = y_runtime.predict(inputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's measure the inferencing speed of ONNX Runtime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "48.7 ms ± 1.23 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "47.7 ms ± 614 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
-    "ort_inputs = dict((ort_session.get_inputs()[i].name, inpt) for i, inpt in enumerate(inputs))\n",
-    "ort_outs = ort_session.run(None, ort_inputs)"
+    "y_runtime.predict(inputs)"
    ]
   },
   {
@@ -484,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -497,7 +527,7 @@
    ],
    "source": [
     "for i in range(0, len(outputs)):\n",
-    "    torch.testing.assert_allclose(outputs[i], ort_outs[i], rtol=1e-04, atol=1e-07)\n",
+    "    torch.testing.assert_allclose(outputs[i], ort_outs1[i], rtol=1e-04, atol=1e-07)\n",
     "\n",
     "print(\"Exported model has been tested with ONNXRuntime, and the result looks good!\")"
    ]
@@ -515,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +574,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,31 +591,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_ort = dict((ort_session.get_inputs()[i].name, inpt) for i, inpt in enumerate(inputs))\n",
-    "out_ort = ort_session.run(None, input_ort)"
+    "ort_outs2 = y_runtime.predict(inputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's measure the inferencing speed of ONNX Runtime."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "37.4 ms ± 775 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "37.5 ms ± 767 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
    "source": [
     "%%timeit\n",
-    "input_ort = dict((ort_session.get_inputs()[i].name, inpt) for i, inpt in enumerate(inputs))\n",
-    "out_ort = ort_session.run(None, input_ort)"
+    "y_runtime.predict(inputs)"
    ]
   },
   {
@@ -597,7 +632,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -610,7 +645,7 @@
    ],
    "source": [
     "for i in range(0, len(outputs)):\n",
-    "    torch.testing.assert_allclose(outputs[i], out_ort[i], rtol=1e-04, atol=1e-07)\n",
+    "    torch.testing.assert_allclose(outputs[i], ort_outs2[i], rtol=1e-04, atol=1e-07)\n",
     "\n",
     "print(\"Exported model has been tested with ONNXRuntime, and the result looks good!\")"
    ]

--- a/test/test_runtime_ort.py
+++ b/test/test_runtime_ort.py
@@ -51,9 +51,9 @@ class TestONNXExporter:
         inputs = list(map(to_numpy, inputs))
         outputs = list(map(to_numpy, outputs))
 
-        ort_session = PredictorORT(onnx_io.getvalue())
+        y_runtime = PredictorORT(onnx_io.getvalue())
         # Inference on ONNX Runtime
-        ort_outs = ort_session.predict(inputs)
+        ort_outs = y_runtime.predict(inputs)
 
         for i in range(0, len(outputs)):
             torch.testing.assert_allclose(outputs[i], ort_outs[i], rtol=1e-03, atol=1e-05)

--- a/test/test_runtime_ort.py
+++ b/test/test_runtime_ort.py
@@ -10,6 +10,7 @@ from torch import Tensor
 from torchvision.io import read_image
 from torchvision.ops._register_onnx_ops import _onnx_opset_version
 from yolort import models
+from yolort.runtime import PredictorORT
 from yolort.runtime.ort_helper import export_onnx
 from yolort.utils.image_utils import to_numpy
 
@@ -50,10 +51,9 @@ class TestONNXExporter:
         inputs = list(map(to_numpy, inputs))
         outputs = list(map(to_numpy, outputs))
 
-        ort_session = onnxruntime.InferenceSession(onnx_io.getvalue())
+        ort_session = PredictorORT(onnx_io.getvalue())
         # Inference on ONNX Runtime
-        ort_inputs = dict((ort_session.get_inputs()[i].name, inpt) for i, inpt in enumerate(inputs))
-        ort_outs = ort_session.run(None, ort_inputs)
+        ort_outs = ort_session.predict(inputs)
 
         for i in range(0, len(outputs)):
             torch.testing.assert_allclose(outputs[i], ort_outs[i], rtol=1e-03, atol=1e-05)

--- a/yolort/data/__init__.py
+++ b/yolort/data/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2021, Zhiqiang Wang. All Rights Reserved.
+# Copyright (c) 2021, yolort team. All rights reserved.
+
 from ._helper import contains_any_tensor
 from .coco_eval import COCOEvaluator
 from .data_module import (
@@ -7,7 +8,7 @@ from .data_module import (
     COCODetectionDataModule,
 )
 
-all = [
+__all__ = [
     "contains_any_tensor",
     "COCOEvaluator",
     "DetectionDataModule",

--- a/yolort/data/_helper.py
+++ b/yolort/data/_helper.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2021, Zhiqiang Wang. All Rights Reserved.
+# Copyright (c) 2021, yolort team. All rights reserved.
+
 import logging
 from pathlib import Path, PosixPath
 from typing import Type, Any

--- a/yolort/runtime/y_onnxruntime.py
+++ b/yolort/runtime/y_onnxruntime.py
@@ -81,7 +81,7 @@ class PredictorORT:
             img_path (str): a image path
 
         Returns:
-            np.ndarray, processed tensor for prediction.
+            np.ndarray, processed ndarray for prediction.
         """
         image = cv2.imread(img_path)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
@@ -106,6 +106,7 @@ class PredictorORT:
     def predict(self, x: Any, image_loader: Optional[Callable] = None) -> List[Dict[str, np.ndarray]]:
         """
         Predict function for raw data or processed data
+
         Args:
             x: Input to predict. Can be raw data or processed data.
             image_loader: Utility function to convert raw data to Numpy ndarray.
@@ -124,7 +125,7 @@ class PredictorORT:
         Args:
             samples (Any): samples source, support the following various types:
                 - str or List[str]: a image path or list of image paths.
-                - np.ndarray or List[np.ndarray]: a tensor or list of tensors.
+                - np.ndarray or List[np.ndarray]: a ndarray or list of ndarray.
 
         Returns:
             List[np.ndarray], The processed image samples.
@@ -147,5 +148,5 @@ class PredictorORT:
 
         raise NotImplementedError(
             f"The type of the sample is {type(samples)}, we currently don't support it now, the "
-            "samples should be either a tensor, list of np.ndarray, a image path or list of image paths."
+            "samples should be either a ndarray, list of np.ndarray, a image path or list of image paths."
         )

--- a/yolort/runtime/y_onnxruntime.py
+++ b/yolort/runtime/y_onnxruntime.py
@@ -1,7 +1,11 @@
+# Copyright (c) 2021, yolort team. All rights reserved.
+
 import logging
+from typing import Any, Dict, List, Callable, Optional
 
 import cv2
 import numpy as np
+from yolort.data import contains_any_tensor
 
 try:
     import onnxruntime as ort
@@ -14,25 +18,33 @@ logger = logging.getLogger(__name__)
 class PredictorORT:
     """
     Create a simple end-to-end predictor with the given checkpoint that runs on
-    single device for a single input image.
+    single device for input images with ONNX Runtime.
 
-    Attributes:
-        checkpoint_path (str): Path of the ONNX checkpoint.
-        enable_gpu (bool, default is False): Whether to enable GPU device.
+    Args:
+        engine_path (string): Path of the serialized ONNX model.
+        device (string): The device to be used for inferencing.
 
-    Examples:
-        >>> from yolort.runtime import PredictorORT
-        >>>
-        >>> checkpoint_path = 'yolov5s.sim.onnx'
-        >>> detector = PredictorORT(checkpoint_path)
-        >>>
-        >>> img_path = 'bus.jpg'
-        >>> scores, class_ids, boxes = detector.run_on_image(img_path)
+    Example:
+
+        Demo pipeline for deploying yolort with ONNX Runtime.
+
+        .. code-block:: python
+
+            import torch
+            from yolort.runtime import PredictorORT
+
+            # Load the exported ONNX model
+            engine_path = 'yolov5n6.onnx'
+            device = 'cpu'
+            y_runtime = PredictorORT(engine_path, device=device)
+
+            # Perform inference on an image file
+            predictions = y_runtime.predict('bus.jpg')
     """
 
-    def __init__(self, checkpoint_path: str, enable_gpu: bool = False) -> None:
-        self.checkpoint_path = checkpoint_path
-        self.enable_gpu = enable_gpu
+    def __init__(self, engine_path: str, device: str = "cpu") -> None:
+        self.engine_path = engine_path
+        self.device = device
         self._providers = self._set_providers()
         self._runtime = self._build_runtime()
         self._input_names = self._runtime.get_inputs()[0].name
@@ -45,10 +57,11 @@ class PredictorORT:
             raise ImportError("ONNXRuntime is not installed, please install onnxruntime firstly.")
         providers = None
 
-        if ort_device == "GPU" and self.enable_gpu:
+        enable_gpu = True if self.device == "cuda" else False
+        if ort_device == "GPU" and enable_gpu:
             providers = ["CUDAExecutionProvider"]
             logger.info("Set inference device to GPU")
-        elif self.enable_gpu:
+        elif enable_gpu:
             logger.info("GPU is not supported by your ONNXRuntime build. Fallback to CPU.")
         else:
             providers = ["CPUExecutionProvider"]
@@ -57,40 +70,82 @@ class PredictorORT:
         return providers
 
     def _build_runtime(self):
-        runtime = ort.InferenceSession(self.checkpoint_path, providers=self._providers)
+        runtime = ort.InferenceSession(self.engine_path, providers=self._providers)
         return runtime
 
-    def _preprocessing(self, image: np.ndarray) -> np.ndarray:
+    def default_loader(self, img_path: str) -> np.ndarray:
+        """
+        Default loader of read a image path.
+
+        Args:
+            img_path (str): a image path
+
+        Returns:
+            np.ndarray, processed tensor for prediction.
+        """
+        image = cv2.imread(img_path)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        blob = image.astype(np.float32) / 255.0
-        blob = np.transpose(blob, axes=(2, 0, 1))
+        image = image.astype(np.float32) / 255.0
+        image = np.transpose(image, axes=(2, 0, 1))
 
-        return blob
+        return image
 
-    def __call__(self, image: np.ndarray):
+    def __call__(self, inputs: List[np.ndarray]):
         """
         Args:
-            image (np.ndarray): an image of shape (H, W, C) (in BGR order).
-                This is the format used by OpenCV.
+            inputs (List[np.ndarray]): a list of images with shape (C, H, W) (in RGB order).
 
         Returns:
             predictions (Tuple[List[float], List[int], List[float, float]]):
                 stands for scores, labels and boxes respectively.
         """
-        blob = self._preprocessing(image)
-        predictions = self._runtime.run(
-            output_names=None,
-            input_feed={self._input_names: blob},
-        )
+        inputs = dict((self._runtime.get_inputs()[i].name, inpt) for i, inpt in enumerate(inputs))
+        predictions = self._runtime.run(output_names=None, input_feed=inputs)
         return predictions
 
-    def run_on_image(self, image_path):
+    def predict(self, x: Any, image_loader: Optional[Callable] = None) -> List[Dict[str, np.ndarray]]:
         """
-        Run the ORT model for one image only.
+        Predict function for raw data or processed data
+        Args:
+            x: Input to predict. Can be raw data or processed data.
+            image_loader: Utility function to convert raw data to Numpy ndarray.
+
+        Returns:
+            The post-processed model predictions.
+        """
+        image_loader = image_loader or self.default_loader
+        images = self.collate_images(x, image_loader)
+        return self(images)
+
+    def collate_images(self, samples: Any, image_loader: Callable) -> List[np.ndarray]:
+        """
+        Prepare source samples for inference.
 
         Args:
-            image_path (str): The image path to be predicted.
+            samples (Any): samples source, support the following various types:
+                - str or List[str]: a image path or list of image paths.
+                - np.ndarray or List[np.ndarray]: a tensor or list of tensors.
+
+        Returns:
+            List[np.ndarray], The processed image samples.
         """
-        img = cv2.imread(image_path)
-        scores, class_ids, boxes = self(img)
-        return scores.tolist(), class_ids.tolist(), boxes.tolist()
+        if isinstance(samples, np.ndarray):
+            return [samples]
+
+        if contains_any_tensor(samples, dtype=np.ndarray):
+            return [sample for sample in samples]
+
+        if isinstance(samples, str):
+            samples = [samples]
+
+        if isinstance(samples, (list, tuple)) and all(isinstance(p, str) for p in samples):
+            outputs = []
+            for sample in samples:
+                output = image_loader(sample)
+                outputs.append(output)
+            return outputs
+
+        raise NotImplementedError(
+            f"The type of the sample is {type(samples)}, we currently don't support it now, the "
+            "samples should be either a tensor, list of np.ndarray, a image path or list of image paths."
+        )

--- a/yolort/runtime/y_onnxruntime.py
+++ b/yolort/runtime/y_onnxruntime.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Any, Dict, List, Callable, Optional
 
-import cv2
 import numpy as np
 from yolort.data import contains_any_tensor
 
@@ -30,10 +29,9 @@ class PredictorORT:
 
         .. code-block:: python
 
-            import torch
             from yolort.runtime import PredictorORT
 
-            # Load the exported ONNX model
+            # Load the serialized ONNX model
             engine_path = 'yolov5n6.onnx'
             device = 'cpu'
             y_runtime = PredictorORT(engine_path, device=device)
@@ -78,11 +76,13 @@ class PredictorORT:
         Default loader of read a image path.
 
         Args:
-            img_path (str): a image path
+            img_path (str): the path to the image
 
         Returns:
             np.ndarray, processed ndarray for prediction.
         """
+        import cv2
+
         image = cv2.imread(img_path)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         image = image.astype(np.float32) / 255.0

--- a/yolort/runtime/y_tensorrt.py
+++ b/yolort/runtime/y_tensorrt.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, yolort team. All rights reserved.
+# Copyright (c) 2022, yolort team. All rights reserved.
 
 import logging
 from collections import OrderedDict, namedtuple
@@ -24,10 +24,10 @@ logger = logging.getLogger("PredictorTRT")
 class PredictorTRT:
     """
     Create a simple end-to-end predictor with the given checkpoint that runs on
-    single device for a single input image.
+    single device for input images with TensorRT.
 
     Args:
-        engine_path (string): Path of the ONNX checkpoint.
+        engine_path (string): Path of the serialized TensorRT engine.
         device (torch.device): The CUDA device to be used for inferencing.
         precision (string): The datatype to use for the engine, either 'fp32', 'fp16' or 'int8'.
         enable_dynamic (bool): Whether to specify axes of tensors as dynamic. Default: False.
@@ -45,6 +45,7 @@ class PredictorTRT:
         Demo pipeline for deploying TensorRT.
 
         .. code-block:: python
+
             import torch
             from yolort.runtime import PredictorTRT
 


### PR DESCRIPTION
```python
from yolort.runtime import PredictorORT

# Load the serialized ONNX model
onnx_path = 'yolov5n6.onnx'
device = 'cpu'
y_runtime = PredictorORT(onnx_path, device=device)

# Perform inference on an image file
predictions = y_runtime.predict('bus.jpg')
```