### PR TITLE
Use C3 following the model specification of YOLOv5

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -12,6 +12,7 @@ from yolort.models.anchor_utils import AnchorGenerator
 from yolort.models.backbone_utils import darknet_pan_backbone
 from yolort.models.box_head import YOLOHead, PostProcess, SetCriterion
 from yolort.models.transformer import darknet_tan_backbone
+from yolort.models.yolo_lite import yolov5_mobilenet_v3_small_fpn
 from yolort.v5 import get_yolov5_size, attempt_download
 
 
@@ -420,3 +421,18 @@ def test_load_from_yolov5_torchscript(arch, size_divisible, version, upstream_ve
     torch.testing.assert_close(out[0]["scores"], out_script[1][0]["scores"], rtol=0, atol=0)
     torch.testing.assert_close(out[0]["labels"], out_script[1][0]["labels"], rtol=0, atol=0)
     torch.testing.assert_close(out[0]["boxes"], out_script[1][0]["boxes"], rtol=0, atol=0)
+
+
+def test_yolov5_mobilenet_v3_small_fpn():
+
+    model = yolov5_mobilenet_v3_small_fpn()
+    model = model.eval()
+
+    images = torch.rand(4, 3, 320, 320)
+    out = model(images)
+    assert isinstance(out, list)
+    assert len(out) == 4
+    assert isinstance(out[0], dict)
+    assert isinstance(out[0]["boxes"], Tensor)
+    assert isinstance(out[0]["labels"], Tensor)
+    assert isinstance(out[0]["scores"], Tensor)

--- a/yolort/models/box_head.py
+++ b/yolort/models/box_head.py
@@ -20,7 +20,7 @@ class YOLOHead(nn.Module):
     ):
         super().__init__()
         if not isinstance(in_channels, list):
-            in_channels = [in_channels] * num_anchors
+            in_channels = [in_channels] * len(strides)
         self.num_anchors = num_anchors  # anchors
         self.num_classes = num_classes
         self.num_outputs = num_classes + 5  # number of outputs per anchor

--- a/yolort/models/yolo_lite.py
+++ b/yolort/models/yolo_lite.py
@@ -143,7 +143,7 @@ def _yolov5_mobilenet_v3_small_fpn(
     if pretrained:
         if model_urls.get(weights_name, None) is None:
             raise ValueError(f"No checkpoint is available for model {weights_name}")
-        state_dict = load_state_dict_from_url(model_urls["retinanet_resnet50_fpn_coco"], progress=progress)
+        state_dict = load_state_dict_from_url(model_urls[weights_name], progress=progress)
         model.load_state_dict(state_dict)
     return model
 


### PR DESCRIPTION
The FPN implemented by TorchVision is a bit different from the PAN layers used by YOLOv5, it will result in 4 layers of output in head  with C3 (YOLOv5 only has 3 layers as a comparison), maybe we can rewrite the BackboneWithFPN in the future following the YOLOv5's PAN.