### PR TITLE
Fix `anchor_grids` for custom trained checkpoints

### DIFF
--- a/yolort/utils/update_module_state.py
+++ b/yolort/utils/update_module_state.py
@@ -60,9 +60,10 @@ def load_from_ultralytics(
     checkpoint_yolov5 = load_yolov5_model(checkpoint_path)
     num_classes = checkpoint_yolov5.yaml["nc"]
     strides = checkpoint_yolov5.stride
-    anchor_grids = checkpoint_yolov5.yaml["anchors"]
-    if isinstance(anchor_grids, int):
-        anchor_grids = to_numpy(checkpoint_yolov5.model[-1].anchor_grid).reshape(3, -1).tolist()
+    # anchor_grids = checkpoint_yolov5.yaml["anchors"]
+    anchor_grids = (
+        checkpoint_yolov5.model[-1].anchors * checkpoint_yolov5.model[-1].stride.view(-1, 1, 1)
+    ).reshape(1, -1, 6).tolist()[0]
 
     depth_multiple = checkpoint_yolov5.yaml["depth_multiple"]
     width_multiple = checkpoint_yolov5.yaml["width_multiple"]

--- a/yolort/utils/update_module_state.py
+++ b/yolort/utils/update_module_state.py
@@ -27,6 +27,7 @@ def convert_yolov5_to_yolort(
         prefix (str): The prefix string of the saved model. Default: "yolov5_darknet_pan".
         postfix (str): The postfix string of the saved model. Default: "custom.pt".
     """
+
     model_info = load_from_ultralytics(checkpoint_path, version=version)
     model_state_dict = model_info["state_dict"]
 
@@ -47,11 +48,7 @@ def load_from_ultralytics(checkpoint_path: str, version: str = "r6.0"):
             values are ["r3.1", "r4.0", "r6.0"]. Default: "r6.0".
     """
 
-    assert version in [
-        "r3.1",
-        "r4.0",
-        "r6.0",
-    ], "Currently does not support this version."
+    assert version in ["r3.1", "r4.0", "r6.0"], "Currently does not support this version."
 
     checkpoint_yolov5 = load_yolov5_model(checkpoint_path)
     num_classes = checkpoint_yolov5.yaml["nc"]
@@ -71,23 +68,8 @@ def load_from_ultralytics(checkpoint_path: str, version: str = "r6.0"):
         use_p6 = True
 
     if use_p6:
-        inner_block_maps = {
-            "0": "11",
-            "1": "12",
-            "3": "15",
-            "4": "16",
-            "6": "19",
-            "7": "20",
-        }
-        layer_block_maps = {
-            "0": "23",
-            "1": "24",
-            "2": "26",
-            "3": "27",
-            "4": "29",
-            "5": "30",
-            "6": "32",
-        }
+        inner_block_maps = {"0": "11", "1": "12", "3": "15", "4": "16", "6": "19", "7": "20"}
+        layer_block_maps = {"0": "23", "1": "24", "2": "26", "3": "27", "4": "29", "5": "30", "6": "32"}
         p6_block_maps = {"0": "9", "1": "10"}
         head_ind = 33
         head_name = "m"
@@ -152,21 +134,10 @@ class ModuleStateUpdate:
 
         # Configuration for making the keys consistent
         if inner_block_maps is None:
-            inner_block_maps = {
-                "0": "9",
-                "1": "10",
-                "3": "13",
-                "4": "14",
-            }
+            inner_block_maps = {"0": "9", "1": "10", "3": "13", "4": "14"}
         self.inner_block_maps = inner_block_maps
         if layer_block_maps is None:
-            layer_block_maps = {
-                "0": "17",
-                "1": "18",
-                "2": "20",
-                "3": "21",
-                "4": "23",
-            }
+            layer_block_maps = {"0": "17", "1": "18", "2": "20", "3": "21", "4": "23"}
         self.layer_block_maps = layer_block_maps
         self.p6_block_maps = p6_block_maps
         self.head_ind = head_ind

--- a/yolort/utils/update_module_state.py
+++ b/yolort/utils/update_module_state.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2020, Zhiqiang Wang. All Rights Reserved.
+# Copyright (c) 2020, yolort team. All rights reserved.
+
 from functools import reduce
 from typing import List, Dict, Optional
 
@@ -35,10 +36,7 @@ def convert_yolov5_to_yolort(
     torch.save(model_state_dict, output_path / output_postfix)
 
 
-def load_from_ultralytics(
-    checkpoint_path: str,
-    version: str = "r6.0",
-):
+def load_from_ultralytics(checkpoint_path: str, version: str = "r6.0"):
     """
     Allows the user to load model state file from the checkpoint trained from
     the ultralytics/yolov5.

--- a/yolort/utils/update_module_state.py
+++ b/yolort/utils/update_module_state.py
@@ -7,8 +7,6 @@ from torch import nn
 from yolort.models import yolo
 from yolort.v5 import load_yolov5_model, get_yolov5_size
 
-from .image_utils import to_numpy
-
 
 def convert_yolov5_to_yolort(
     checkpoint_path: str,
@@ -62,8 +60,10 @@ def load_from_ultralytics(
     strides = checkpoint_yolov5.stride
     # anchor_grids = checkpoint_yolov5.yaml["anchors"]
     anchor_grids = (
-        checkpoint_yolov5.model[-1].anchors * checkpoint_yolov5.model[-1].stride.view(-1, 1, 1)
-    ).reshape(1, -1, 6).tolist()[0]
+        (checkpoint_yolov5.model[-1].anchors * checkpoint_yolov5.model[-1].stride.view(-1, 1, 1))
+        .reshape(1, -1, 6)
+        .tolist()[0]
+    )
 
     depth_multiple = checkpoint_yolov5.yaml["depth_multiple"]
     width_multiple = checkpoint_yolov5.yaml["width_multiple"]


### PR DESCRIPTION
Seems that YOLOv5 will change the anchors setting when using the auto-anchor mechanism. So instead of attaching the `anchor_grids` via `checkpoint_yolov5.yaml["anchors"]`, we use the following formula to compute the `anchor_grids`:

```python
anchor_grids = (
    (checkpoint_yolov5.model[-1].anchors * checkpoint_yolov5.model[-1].stride.view(-1, 1, 1))
    .reshape(1, -1, 6)
    .tolist()[0]
)
```
