### PR TITLE
Remove lightning dependencies

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -68,6 +68,9 @@ jobs:
           pip install --user --progress-bar off pycocotools>=2.0.2
           pip install --user --progress-bar off onnx
           pip install --user --progress-bar off onnxruntime
+          pip install --user --progress-bar off pytorch_lightning
+          pip install --user --progress-bar off torchmetric
+          pip install --user --progress-bar off onnxruntime
           pip install --user onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
 
       - name: Lint with flake8

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -69,7 +69,7 @@ jobs:
           pip install --user --progress-bar off onnx
           pip install --user --progress-bar off onnxruntime
           pip install --user --progress-bar off pytorch_lightning
-          pip install --user --progress-bar off torchmetric
+          pip install --user --progress-bar off torchmetrics
           pip install --user --progress-bar off onnxruntime
           pip install --user onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,10 +24,6 @@ ipython
 tabulate
 pandas
 
-# Lightning -----------------------------------
-pytorch_lightning>=1.3.1
-torchmetrics
-
 # extras --------------------------------------
 # pycocotools on PyPI needs python3.7 as minimal
 # pycocotools>=2.0.2  # corresponds to https://github.com/ppwwyyxx/cocoapi

--- a/test/test_data_pipeline.py
+++ b/test/test_data_pipeline.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import numpy as np
 import torch
 from torch import Tensor
-from yolort.data import DetectionDataModule, contains_any_tensor, _helper as data_helper
+from yolort.data import contains_any_tensor, _helper as data_helper
+from yolort.data.data_module import DetectionDataModule
 
 
 def test_contains_any_tensor():

--- a/test/test_models_yolov5.py
+++ b/test/test_models_yolov5.py
@@ -4,7 +4,8 @@ import pytest
 import torch
 from torch import Tensor
 from torchvision.io import read_image
-from yolort.data import COCOEvaluator, _helper as data_helper
+from yolort.data import _helper as data_helper
+from yolort.data.coco_eval import COCOEvaluator
 from yolort.models import yolov5s
 from yolort.models.transform import YOLOTransform
 from yolort.models.yolo import yolov5_darknet_pan_s_r31

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 import pytorch_lightning as pl
-from yolort.data import DetectionDataModule, _helper as data_helper
+from yolort.data import _helper as data_helper
+from yolort.data.data_module import DetectionDataModule
 from yolort.trainer import DefaultTask
 
 

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import torch
 import torchvision
 import yolort
-from yolort.data import COCOEvaluator, _helper as data_helper
+from yolort.data import _helper as data_helper
+from yolort.data.coco_eval import COCOEvaluator
 from yolort.data.coco import COCODetection
 from yolort.data.transforms import default_val_transforms, collate_fn
 from yolort.utils.logger import MetricLogger

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -8,8 +8,8 @@ import torch
 import torchvision
 import yolort
 from yolort.data import _helper as data_helper
-from yolort.data.coco_eval import COCOEvaluator
 from yolort.data.coco import COCODetection
+from yolort.data.coco_eval import COCOEvaluator
 from yolort.data.transforms import default_val_transforms, collate_fn
 from yolort.utils.logger import MetricLogger
 

--- a/yolort/data/__init__.py
+++ b/yolort/data/__init__.py
@@ -1,17 +1,5 @@
 # Copyright (c) 2021, yolort team. All rights reserved.
 
 from ._helper import contains_any_tensor
-from .coco_eval import COCOEvaluator
-from .data_module import (
-    DetectionDataModule,
-    VOCDetectionDataModule,
-    COCODetectionDataModule,
-)
 
-__all__ = [
-    "contains_any_tensor",
-    "COCOEvaluator",
-    "DetectionDataModule",
-    "VOCDetectionDataModule",
-    "COCODetectionDataModule",
-]
+__all__ = ["contains_any_tensor"]

--- a/yolort/models/_utils.py
+++ b/yolort/models/_utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2020, yolort team. All rights reserved.
+
 import math
 from typing import Tuple, Optional
 

--- a/yolort/models/darknet.py
+++ b/yolort/models/darknet.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2021, yolort team. All rights reserved.
+
 from .darknetv4 import (
     DarkNetV4,
     darknet_s_r3_1,

--- a/yolort/models/darknetv4.py
+++ b/yolort/models/darknetv4.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2021, Zhiqiang Wang. All Rights Reserved.
+# Copyright (c) 2021, yolort team. All rights reserved.
+
 from typing import Callable, List, Optional, Any
 
 import torch

--- a/yolort/models/darknetv6.py
+++ b/yolort/models/darknetv6.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021, yolort team. All rights reserved.
-from typing import Callable, List, Optional, Any
+
+from typing import Any, Callable, List, Optional
 
 import torch
 from torch import nn, Tensor

--- a/yolort/models/path_aggregation_network.py
+++ b/yolort/models/path_aggregation_network.py
@@ -1,5 +1,6 @@
-# Copyright (c) 2021, Zhiqiang Wang. All Rights Reserved.
-from typing import List, Dict, Callable, Optional
+# Copyright (c) 2021, yolort team. All rights reserved.
+
+from typing import Dict, List, Callable, Optional
 
 import torch
 from torch import nn, Tensor

--- a/yolort/models/transformer.py
+++ b/yolort/models/transformer.py
@@ -1,9 +1,5 @@
-# Copyright (c) 2021, Zhiqiang Wang. All Rights Reserved.
-"""
-The transformer attention network blocks.
+# Copyright (c) 2021, yolort team. All rights reserved.
 
-Mostly copy-paste from <https://github.com/dingyiwei/yolov5/tree/Transformer>.
-"""
 from typing import Callable, List, Optional
 
 from torch import nn

--- a/yolort/trainer/lightning_task.py
+++ b/yolort/trainer/lightning_task.py
@@ -9,7 +9,7 @@ import yolort.models as models
 from pytorch_lightning import LightningModule
 from torch import Tensor
 from torchvision.ops import box_iou
-from yolort.data import COCOEvaluator
+from yolort.data.coco_eval import COCOEvaluator
 
 
 __all__ = ["DefaultTask"]


### PR DESCRIPTION
As mentioned in #219 , if someone just wants to use the models for inference, he/she doesn't need all additional features like:

- pytorch-lightning
- torchmetrics