### PR TITLE
Fix building docs and update docstrings

### DIFF
--- a/deployment/libtorch/README.md
+++ b/deployment/libtorch/README.md
@@ -18,6 +18,7 @@ The LibTorch inference for `yolort`, both GPU and CPU are supported.
 
    ```bash
    export TORCH_PATH=$(dirname $(python -c "import torch; print(torch.__file__)"))
+   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TORCH_PATH/lib/  # Optional
    ```
 
 1. Don't forget to compile `LibTorchVision` using the following scripts.

--- a/deployment/libtorch/README.md
+++ b/deployment/libtorch/README.md
@@ -4,13 +4,12 @@ The LibTorch inference for `yolort`, both GPU and CPU are supported.
 
 ## Dependencies
 
-- Ubuntu 18.04
-- LibTorch 1.8.0 / 1.9.0
-- TorchVision 0.9.0 / 0.10.0
+- Ubuntu / Windows / macOS
+- LibTorch 1.8.0+ together with corresponding TorchVision 0.9.0+
 - OpenCV 3.4+
 - CUDA 10.2 \[Optional\]
 
-*We didn't impose too strong restrictions on the version of CUDA and Ubuntu systems.*
+*We didn't impose too strong restrictions on the version of CUDA.*
 
 ## Usage
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ ipython
 sphinx
 sphinx-material
 nbsphinx
+PyYAML>=5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@
 matplotlib>=3.2.2
 numpy>=1.18.5
 Pillow>=8.0.0
+PyYAML>=5.3.1
 scipy>=1.4.1
 tqdm>=4.41.0
 


### PR DESCRIPTION
In some circumstances, adding `TORCH_PATH` to the `LD_LIBRARY_PATH` environment variable will reduce some errors of finding CUDA.