### PR TITLE
Fix TensorRT Windows Python interface compatibility

### DIFF
--- a/yolort/runtime/y_tensorrt.py
+++ b/yolort/runtime/y_tensorrt.py
@@ -3,14 +3,15 @@
 import logging
 from collections import OrderedDict, namedtuple
 from typing import Any, Dict, List, Callable, Optional, Tuple
-#import yolort before pytorch: this may cause issue in python inference on windows
+
+# import yolort before pytorch: this may cause issue in python inference on windows
 import yolort.utils.dependency as _dependency
+
 if _dependency.is_module_available("tensorrt"):
     import tensorrt as trt
 
 import numpy as np
 import torch
-
 from torch import Tensor
 from torchvision.io import read_image
 from yolort.models.transform import YOLOTransform

--- a/yolort/runtime/y_tensorrt.py
+++ b/yolort/runtime/y_tensorrt.py
@@ -3,17 +3,19 @@
 import logging
 from collections import OrderedDict, namedtuple
 from typing import Any, Dict, List, Callable, Optional, Tuple
+#import yolort before pytorch: this may cause issue in python inference on windows
+import yolort.utils.dependency as _dependency
+if _dependency.is_module_available("tensorrt"):
+    import tensorrt as trt
 
 import numpy as np
 import torch
-import yolort.utils.dependency as _dependency
+
 from torch import Tensor
 from torchvision.io import read_image
 from yolort.models.transform import YOLOTransform
 from yolort.utils import contains_any_tensor
 
-if _dependency.is_module_available("tensorrt"):
-    import tensorrt as trt
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("PredictorTRT").setLevel(logging.INFO)


### PR DESCRIPTION
This is an update about to tensorrt python inference on windows:

import yolort before pytorch, this resolve issue in python inference on windows.

Close #390 