### PR TITLE
Add Weights and Biases to `MetricLogger` Class

### DIFF
--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -163,7 +163,7 @@ def eval_metric(args):
 @torch.no_grad()
 def evaluate(model, data_loader, coco_evaluator, device, print_freq, use_wandb, wandb_project, wandb_entity):
     # COCO evaluation
-    metric_logger = MetricLogger(args, delimiter="  ")
+    metric_logger = MetricLogger(delimiter="  ", use_wandb, wandb_project, wandb_entity)
     header = "Test:"
     for images, targets in metric_logger.log_every(data_loader, print_freq, header):
         images = list(image.to(device) for image in images)

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -163,7 +163,9 @@ def eval_metric(args):
 @torch.no_grad()
 def evaluate(model, data_loader, coco_evaluator, device, print_freq, use_wandb, wandb_project, wandb_entity):
     # COCO evaluation
-    metric_logger = MetricLogger(delimiter="  ", use_wandb=use_wandb, wandb_project=wandb_project, wandb_entity=wandb_entity)
+    metric_logger = MetricLogger(
+        delimiter="  ", use_wandb=use_wandb, wandb_project=wandb_project, wandb_entity=wandb_entity
+    )
     header = "Test:"
     for images, targets in metric_logger.log_every(data_loader, print_freq, header):
         images = list(image.to(device) for image in images)

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -67,6 +67,12 @@ def get_parser():
         help="The frequency of printing the logging",
     )
     parser.add_argument("--output_dir", default=".", help="Path where to save")
+    
+    # Weights and Biases arguments
+    parser.add_argument("--use_wandb", default=True, type = bool, help = "Whether to use W&B for metric logging")
+    parser.add_argument("--wandb_project", default="yolov5-rt", type=str, help="Name of the W&B Project")
+    parser.add_argument("--wandb_entity", default=None, type=str, help="entity to use for W&B logging")
+    
     return parser
 
 
@@ -136,7 +142,7 @@ def eval_metric(args):
     model = model.to(device)
 
     print("Computing the mAP...")
-    results = evaluate(model, data_loader, coco_evaluator, device, args.print_freq)
+    results = evaluate(model, data_loader, coco_evaluator, device, args.print_freq, args)
 
     # mAP results
     print(
@@ -146,9 +152,9 @@ def eval_metric(args):
 
 
 @torch.no_grad()
-def evaluate(model, data_loader, coco_evaluator, device, print_freq):
+def evaluate(model, data_loader, coco_evaluator, device, print_freq, args):
     # COCO evaluation
-    metric_logger = MetricLogger(delimiter="  ")
+    metric_logger = MetricLogger(args, delimiter="  ")
     header = "Test:"
     for images, targets in metric_logger.log_every(data_loader, print_freq, header):
         images = list(image.to(device) for image in images)

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -142,7 +142,7 @@ def eval_metric(args):
     model = model.to(device)
 
     print("Computing the mAP...")
-    results = evaluate(model, data_loader, coco_evaluator, device, args.print_freq, args)
+    results = evaluate(model, data_loader, coco_evaluator, device, args.print_freq, args.use_wandb, args.wandb_project, args.wandb_entity)
 
     # mAP results
     print(
@@ -152,7 +152,7 @@ def eval_metric(args):
 
 
 @torch.no_grad()
-def evaluate(model, data_loader, coco_evaluator, device, print_freq, args):
+def evaluate(model, data_loader, coco_evaluator, device, print_freq, use_wandb, wandb_project, wandb_entity):
     # COCO evaluation
     metric_logger = MetricLogger(args, delimiter="  ")
     header = "Test:"

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -67,12 +67,12 @@ def get_parser():
         help="The frequency of printing the logging",
     )
     parser.add_argument("--output_dir", default=".", help="Path where to save")
-    
+
     # Weights and Biases arguments
-    parser.add_argument("--use_wandb", default=True, type = bool, help = "Whether to use W&B for metric logging")
+    parser.add_argument("--use_wandb", default=True, type=bool, help="Whether to use W&B for metric logging")
     parser.add_argument("--wandb_project", default="yolov5-rt", type=str, help="Name of the W&B Project")
     parser.add_argument("--wandb_entity", default=None, type=str, help="entity to use for W&B logging")
-    
+
     return parser
 
 

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -163,7 +163,7 @@ def eval_metric(args):
 @torch.no_grad()
 def evaluate(model, data_loader, coco_evaluator, device, print_freq, use_wandb, wandb_project, wandb_entity):
     # COCO evaluation
-    metric_logger = MetricLogger(delimiter="  ", use_wandb, wandb_project, wandb_entity)
+    metric_logger = MetricLogger(use_wandb, wandb_project, wandb_entity, delimiter="  ")
     header = "Test:"
     for images, targets in metric_logger.log_every(data_loader, print_freq, header):
         images = list(image.to(device) for image in images)

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -142,7 +142,16 @@ def eval_metric(args):
     model = model.to(device)
 
     print("Computing the mAP...")
-    results = evaluate(model, data_loader, coco_evaluator, device, args.print_freq, args.use_wandb, args.wandb_project, args.wandb_entity)
+    results = evaluate(
+        model,
+        data_loader,
+        coco_evaluator,
+        device,
+        args.print_freq,
+        args.use_wandb,
+        args.wandb_project,
+        args.wandb_entity,
+    )
 
     # mAP results
     print(

--- a/tools/eval_metric.py
+++ b/tools/eval_metric.py
@@ -163,7 +163,7 @@ def eval_metric(args):
 @torch.no_grad()
 def evaluate(model, data_loader, coco_evaluator, device, print_freq, use_wandb, wandb_project, wandb_entity):
     # COCO evaluation
-    metric_logger = MetricLogger(use_wandb, wandb_project, wandb_entity, delimiter="  ")
+    metric_logger = MetricLogger(delimiter="  ", use_wandb=use_wandb, wandb_project=wandb_project, wandb_entity=wandb_entity)
     header = "Test:"
     for images, targets in metric_logger.log_every(data_loader, print_freq, header):
         images = list(image.to(device) for image in images)

--- a/yolort/utils/logger.py
+++ b/yolort/utils/logger.py
@@ -5,6 +5,12 @@ from collections import defaultdict, deque
 import torch
 import torch.distributed as dist
 
+try:
+    import wandb
+
+    assert hasattr(wandb, '__version__')  # verify package import not local dir
+except (ImportError, AssertionError):
+    wandb = None
 
 class SmoothedValue:
     """Track a series of values and provide access to smoothed values over a
@@ -70,9 +76,12 @@ class SmoothedValue:
 
 
 class MetricLogger:
-    def __init__(self, delimiter="\t"):
+    def __init__(self, args, delimiter="\t"):
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
+        self.use_wandb = args.use_wandb
+        if is_main_process() and self.use_wandb:
+                self.wandb_run = wandb.init(project=args.wandb_project, entity=args.wandb_entity, config=args)
 
     def update(self, **kwargs):
         for k, v in kwargs.items():
@@ -80,6 +89,8 @@ class MetricLogger:
                 v = v.item()
             assert isinstance(v, (float, int))
             self.meters[k].update(v)
+            if is_main_process() and self.wandb_run:
+                wandb.log({k:v})
 
     def __getattr__(self, attr):
         if attr in self.meters:
@@ -177,3 +188,12 @@ def is_dist_avail_and_initialized():
     if not dist.is_initialized():
         return False
     return True
+
+def get_rank():
+    if not is_dist_avail_and_initialized():
+        return 0
+    return dist.get_rank()
+
+
+def is_main_process():
+    return get_rank() == 0

--- a/yolort/utils/logger.py
+++ b/yolort/utils/logger.py
@@ -77,12 +77,12 @@ class SmoothedValue:
 
 
 class MetricLogger:
-    def __init__(self, args, delimiter="\t"):
+    def __init__(self, delimiter="\t", use_wandb = True, wandb_project="yolov5-rt", wandb_entity=None):
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
-        self.use_wandb = args.use_wandb
+        self.use_wandb = use_wandb
         if is_main_process() and self.use_wandb:
-            self.wandb_run = wandb.init(project=args.wandb_project, entity=args.wandb_entity, config=args)
+            self.wandb_run = wandb.init(project=wandb_project, entity=wandb_entity)
 
     def update(self, **kwargs):
         for k, v in kwargs.items():

--- a/yolort/utils/logger.py
+++ b/yolort/utils/logger.py
@@ -77,7 +77,7 @@ class SmoothedValue:
 
 
 class MetricLogger:
-    def __init__(self, delimiter="\t", use_wandb = True, wandb_project="yolov5-rt", wandb_entity=None):
+    def __init__(self, delimiter="\t", use_wandb=True, wandb_project="yolov5-rt", wandb_entity=None):
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
         self.use_wandb = use_wandb

--- a/yolort/utils/logger.py
+++ b/yolort/utils/logger.py
@@ -8,9 +8,10 @@ import torch.distributed as dist
 try:
     import wandb
 
-    assert hasattr(wandb, '__version__')  # verify package import not local dir
+    assert hasattr(wandb, "__version__")  # verify package import not local dir
 except (ImportError, AssertionError):
     wandb = None
+
 
 class SmoothedValue:
     """Track a series of values and provide access to smoothed values over a
@@ -81,7 +82,7 @@ class MetricLogger:
         self.delimiter = delimiter
         self.use_wandb = args.use_wandb
         if is_main_process() and self.use_wandb:
-                self.wandb_run = wandb.init(project=args.wandb_project, entity=args.wandb_entity, config=args)
+            self.wandb_run = wandb.init(project=args.wandb_project, entity=args.wandb_entity, config=args)
 
     def update(self, **kwargs):
         for k, v in kwargs.items():
@@ -90,7 +91,7 @@ class MetricLogger:
             assert isinstance(v, (float, int))
             self.meters[k].update(v)
             if is_main_process() and self.wandb_run:
-                wandb.log({k:v})
+                wandb.log({k: v})
 
     def __getattr__(self, attr):
         if attr in self.meters:
@@ -188,6 +189,7 @@ def is_dist_avail_and_initialized():
     if not dist.is_initialized():
         return False
     return True
+
 
 def get_rank():
     if not is_dist_avail_and_initialized():


### PR DESCRIPTION
This PR aims to add basic [Weights and Biases](https://wandb.ai/site) Metric Logging by appending to the existing MetricLogger Class defined in [logger.py](https://github.com/zhiqwang/yolov5-rt-stack/blob/main/yolort/utils/logger.py) with minimal changes while supporting Multiple GPU logging with torch distributed.

The changes can be summarized as follows :-

* Pass the `args` to the `MetricLogger` which if the `--use_wandb` is set to `True`, creates and run and logs metrics using the `update` function.
* Add 3 extra arguments namely `--use_wandb`, `--wandb_project` and `--wandb_entity` which can be used to specify whether to use wandb, the name of the project to be used ("yolov5-rt" by default) and name of the entity to be used.