### PR TITLE
Support ONNX exported from YOLOv5 and YOLOv6

### DIFF
--- a/yolort/relay/trt_graphsurgeon.py
+++ b/yolort/relay/trt_graphsurgeon.py
@@ -121,7 +121,7 @@ class YOLOTRTGraphSurgeon:
 
     def _process(self,dtype):
         Matrix = np.array([[1.0, 0.0, 1.0, 0.0], [0.0, 1.0, 0.0, 1.0],
-                           [-0.5, 0.0, 0.5, 0.0], [0.0, -0.5, 0.0, 0.5]], dtype=np.float32)
+                           [-0.5, 0.0, 0.5, 0.0], [0.0, -0.5, 0.0, 0.5]], dtype=dtype)
         Attrs = [[5, 9999, 2, 1], [4, 5, 2, 1], [0, 4, 2, 1]]
         lastNode = [node for node in self.graph.nodes if node.outputs and node.outputs[0] in self.graph.outputs][0]
         out_shape = lastNode.outputs[0].shape

--- a/yolort/relay/trt_graphsurgeon.py
+++ b/yolort/relay/trt_graphsurgeon.py
@@ -73,10 +73,10 @@ class YOLOTRTGraphSurgeon:
                 input_sample = input_sample.to(device=device)
             model_path = model_path.with_suffix(".onnx")
             model.to_onnx(model_path, input_sample=input_sample, enable_dynamic=enable_dynamic)
+            logger.info("PyTorch2ONNX graph created successfully")
         # Use YOLOTRTInference to modify an existed ONNX graph.
         self.graph = gs.import_onnx(onnx.load(model_path))
         assert self.graph
-        logger.info("PyTorch2ONNX graph created successfully")
 
         # Fold constants via ONNX-GS that PyTorch2ONNX may have missed
         self.graph.fold_constants()

--- a/yolort/relay/trt_graphsurgeon.py
+++ b/yolort/relay/trt_graphsurgeon.py
@@ -96,8 +96,6 @@ class YOLOTRTGraphSurgeon:
             try:
                 for node in self.graph.nodes:
                     for o in node.outputs:
-                        if o in self.graph.outputs:
-                            continue
                         o.shape = None
                 model = gs.export_onnx(self.graph)
                 model = shape_inference.infer_shapes(model)
@@ -144,8 +142,8 @@ class YOLOTRTGraphSurgeon:
                 matmul_inputs[0] = Slice_out
         mut_output = gs.Variable(name="NMS_Scores", shape=out_shape[:2] + [out_shape[2] - 5], dtype=dtype)
         matmut_output = gs.Variable(name="NMS_Boxes", shape=out_shape[:2] + [4], dtype=dtype)
-        self.graph.layer(name=f"AddMul_0", op="Mul", inputs=mul_inputs, outputs=[mut_output])
-        self.graph.layer(name=f"AddMatMul_0", op="MatMul", inputs=matmul_inputs, outputs=[matmut_output])
+        self.graph.layer(name="AddMul_0", op="Mul", inputs=mul_inputs, outputs=[mut_output])
+        self.graph.layer(name="AddMatMul_0", op="MatMul", inputs=matmul_inputs, outputs=[matmut_output])
         self.graph.outputs = [matmut_output, mut_output]
 
     def save(self, output_path):

--- a/yolort/relay/trt_inference.py
+++ b/yolort/relay/trt_inference.py
@@ -23,11 +23,11 @@ class YOLOTRTInference(nn.Module):
     inference frameworks currently do not support this operator very well.
 
     Args:
-        checkpoint_path (string): Path of the trained YOLOv5 checkpoint.
+        checkpoint_path (Union[string, PosixPath]): Path of the trained YOLOv5 checkpoint.
         version (string): Upstream YOLOv5 version. Default: 'r6.0'
     """
 
-    def __init__(self, checkpoint_path: str, version: str = "r6.0"):
+    def __init__(self, checkpoint_path: Union[str, PosixPath], version: str = "r6.0"):
         super().__init__()
         model_info = load_from_ultralytics(checkpoint_path, version=version)
 

--- a/yolort/runtime/trt_helper.py
+++ b/yolort/runtime/trt_helper.py
@@ -46,7 +46,7 @@ def export_tensorrt_engine(
     Export ONNX models and TensorRT serialized engines that can be used for TensorRT inferencing.
 
     Args:
-        checkpoint_path (str): Path of the YOLOv5 checkpoint model.
+        checkpoint_path (Union[string, PosixPath]): Path of the YOLOv5 checkpoint model or onnx model.
         score_thresh (float): Score threshold used for postprocessing the detections. Default: 0.25
         nms_thresh (float): NMS threshold used for postprocessing the detections. Default: 0.45
         version (str): upstream version released by the ultralytics/yolov5, Possible
@@ -65,6 +65,7 @@ def export_tensorrt_engine(
 
     if input_sample is None:
         input_sample = torch.rand(1, 3, 640, 640)
+
 
     yolo_gs = YOLOTRTGraphSurgeon(checkpoint_path, version=version, input_sample=input_sample)
 


### PR DESCRIPTION
I have tested yolov5s and yolov6s onnx.
Now `export_tensorrt_engine` api support onnx input which is exported by yolov5 / yolov6 original repo onnx export.